### PR TITLE
feat: Update plugin to support PaperMC 1.21 and fix build issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ KartaEmeraldCurrency is a modern, high-performance economy plugin for PaperMC se
 
 Built to be efficient and safe, all database operations are handled asynchronously to prevent server lag.
 
-**Compatibility:** PaperMC 1.19.4 – 1.21.8 (Java 17+)
+**Compatibility:** PaperMC 1.21 – 1.21.8 (Java 21+)
 
 ## Features
 
@@ -47,18 +47,19 @@ All admin commands require the base permission `kec.admin` or granular permissio
 | `/kecadmin give <player> <amount>` | `kec.admin.give` | Gives a player physical emeralds. |
 | `/kecadmin take <player> <amount>` | `kec.admin.take` | Takes physical emeralds from a player. |
 | `/kecadmin reload` | `kec.admin.reload` | Reloads the configuration files. |
+| `/kecadmin migrate <source_type>` | `kec.admin.migrate` | Migrates data from one storage type to another (e.g., SQLITE to MYSQL). |
 
 ## Placeholders
 
 Requires [PlaceholderAPI](https://www.spigotmc.org/resources/placeholderapi.624/).
 
-- `%kartaemerald_balance%` - Player's balance (source configurable: BANK or TOTAL).
-- `%kartaemerald_balance_formatted%` - Player's balance formatted (e.g., 1.2k).
-- `%kartaemerald_balance_comma%` - Player's balance with commas (e.g., 1,234,567).
-- `%kartaemerald_bank%` - Player's bank balance.
-- `%kartaemerald_wallet%` - Player's physical emerald count in inventory.
-- `%kartaemerald_top_<1-10>_name%` - Name of the Nth player on the leaderboard.
-- `%kartaemerald_top_<1-10>_amount%` - Balance of the Nth player on the leaderboard.
+- `%kartaemerald_balance%` - Player's total bank balance.
+- `%kartaemerald_balance_formatted%` - Player's bank balance, formatted with suffixes (e.g., 1.2k).
+- `%kartaemerald_balance_comma%` - Player's bank balance, formatted with commas (e.g., 1,234,567).
+- `%kartaemerald_bank%` - An alias for `%kartaemerald_balance%`.
+- `%kartaemerald_wallet%` - Player's physical emerald count in their inventory.
+- `%kartaemerald_top_<1-10>_name%` - **(Not yet implemented)** Name of the Nth player on the leaderboard.
+- `%kartaemerald_top_<1-10>_amount%` - **(Not yet implemented)** Balance of the Nth player on the leaderboard.
 
 ## Developer API
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,14 +7,14 @@ file("gradle.properties").inputStream().use { properties.load(it) }
 
 plugins {
     java
-    id("com.github.johnrengelman.shadow") version "8.1.1"
+    id("com.gradleup.shadow") version "8.3.0"
 }
 
 group = properties.getProperty("pluginGroupId")
 version = properties.getProperty("pluginVersion")
 
 java {
-    toolchain.languageVersion.set(JavaLanguageVersion.of(17))
+    toolchain.languageVersion.set(JavaLanguageVersion.of(21))
     withJavadocJar()
     withSourcesJar()
 }
@@ -29,7 +29,7 @@ repositories {
 dependencies {
     // Compile-Only Dependencies (provided by server or other plugins)
     compileOnly("io.papermc.paper:paper-api:${properties.getProperty("paperApiVersion")}")
-    compileOnly("com.github.MilkBowl:VaultAPI:${properties.getProperty("vaultApiVersion")}")
+    compileOnly("com.github.milkbowl:VaultAPI:${properties.getProperty("vaultApiVersion")}")
     compileOnly("me.clip:placeholderapi:${properties.getProperty("placeholderApiVersion")}")
     compileOnly("mysql:mysql-connector-java:8.0.33") // For compiling against, not for bundling
 
@@ -44,6 +44,7 @@ tasks {
     withType<JavaCompile> {
         options.encoding = "UTF-8"
         options.compilerArgs.addAll(listOf("-Xlint:all,-serial", "-parameters"))
+        options.release.set(21)
     }
 
     // Configure the shadowJar task

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,8 +3,9 @@ org.gradle.java.installations.auto-download=true
 pluginGroupId=com.minekarta
 pluginVersion=1.0.0
 
-paperApiVersion=1.19.4-R0.1-SNAPSHOT
-vaultApiVersion=1.7
+paperApiVersion=1.21-R0.1-SNAPSHOT
+# VaultAPI version 1.7.3 was not found in JitPack, using the latest available version (1.7.1).
+vaultApiVersion=1.7.1
 placeholderApiVersion=2.11.6
 hikariVersion=5.1.0
 miniMessageVersion=4.17.0

--- a/src/main/java/com/minekarta/kec/KartaEmeraldCurrencyPlugin.java
+++ b/src/main/java/com/minekarta/kec/KartaEmeraldCurrencyPlugin.java
@@ -20,6 +20,10 @@ import java.io.IOException;
 import java.util.Properties;
 import java.util.concurrent.Executor;
 
+/**
+ * The main plugin class for KartaEmeraldCurrency.
+ * Handles loading, enabling, and disabling of the plugin's features.
+ */
 public class KartaEmeraldCurrencyPlugin extends JavaPlugin {
 
     private static KartaEmeraldCurrencyPlugin instance;
@@ -32,6 +36,10 @@ public class KartaEmeraldCurrencyPlugin extends JavaPlugin {
     private FileConfiguration guiConfig;
     private FileConfiguration databaseConfig;
 
+    /**
+     * Called when the plugin is enabled.
+     * Initializes configurations, database, services, and hooks.
+     */
     @Override
     public void onEnable() {
         instance = this;
@@ -59,6 +67,10 @@ public class KartaEmeraldCurrencyPlugin extends JavaPlugin {
         getLogger().info("KartaEmeraldCurrency has been enabled successfully.");
     }
 
+    /**
+     * Called when the plugin is disabled.
+     * Closes the database connection.
+     */
     @Override
     public void onDisable() {
         if (storage != null) {
@@ -157,22 +169,42 @@ public class KartaEmeraldCurrencyPlugin extends JavaPlugin {
         // TODO: Register other listeners like PlayerJoinListener
     }
 
+    /**
+     * Gets the singleton instance of the plugin.
+     * @return The plugin instance.
+     */
     public static KartaEmeraldCurrencyPlugin getInstance() {
         return instance;
     }
 
+    /**
+     * Gets the active KartaEmeraldService API instance.
+     * @return The economy service.
+     */
     public KartaEmeraldService getService() {
         return service;
     }
 
+    /**
+     * Gets the main plugin configuration (config.yml).
+     * @return The main configuration.
+     */
     public FileConfiguration getPluginConfig() {
         return getConfig();
     }
 
+    /**
+     * Gets the messages configuration (messages.yml).
+     * @return The messages configuration.
+     */
     public FileConfiguration getMessagesConfig() {
         return messagesConfig;
     }
 
+    /**
+     * Gets the GUI configuration (gui.yml).
+     * @return The GUI configuration.
+     */
     public FileConfiguration getGuiConfig() {
         return guiConfig;
     }

--- a/src/main/java/com/minekarta/kec/placeholder/KecPlaceholderExpansion.java
+++ b/src/main/java/com/minekarta/kec/placeholder/KecPlaceholderExpansion.java
@@ -28,7 +28,7 @@ public class KecPlaceholderExpansion extends PlaceholderExpansion {
 
     @Override
     public @NotNull String getVersion() {
-        return plugin.getDescription().getVersion();
+        return plugin.getPluginMeta().getVersion();
     }
 
     @Override

--- a/src/main/java/com/minekarta/kec/vault/VaultEconomyAdapter.java
+++ b/src/main/java/com/minekarta/kec/vault/VaultEconomyAdapter.java
@@ -17,14 +17,6 @@ public class VaultEconomyAdapter extends AbstractEconomy {
         this.service = service;
     }
 
-    // A utility to convert our service's boolean future to a Vault EconomyResponse
-    private EconomyResponse handleFutureResponse(boolean success, double amount, String failureMessage) {
-        if (success) {
-            return new EconomyResponse(amount, getBalance(Bukkit.getOfflinePlayer(failureMessage)), EconomyResponse.ResponseType.SUCCESS, null);
-        } else {
-            return new EconomyResponse(0, 0, EconomyResponse.ResponseType.FAILURE, failureMessage);
-        }
-    }
 
     @Override
     public boolean isEnabled() {
@@ -83,7 +75,11 @@ public class VaultEconomyAdapter extends AbstractEconomy {
             return new EconomyResponse(0, getBalance(player), EconomyResponse.ResponseType.FAILURE, "Cannot withdraw negative funds.");
         }
         boolean success = service.removeBankBalance(player.getUniqueId(), (long) amount).join();
-        return handleFutureResponse(success, amount, "Insufficient funds.");
+        if (success) {
+            return new EconomyResponse(amount, getBalance(player), EconomyResponse.ResponseType.SUCCESS, null);
+        } else {
+            return new EconomyResponse(0, getBalance(player), EconomyResponse.ResponseType.FAILURE, "Insufficient funds.");
+        }
     }
 
     @Override
@@ -92,7 +88,11 @@ public class VaultEconomyAdapter extends AbstractEconomy {
             return new EconomyResponse(0, getBalance(player), EconomyResponse.ResponseType.FAILURE, "Cannot deposit negative funds.");
         }
         boolean success = service.addBankBalance(player.getUniqueId(), (long) amount).join();
-        return handleFutureResponse(success, amount, "Failed to deposit.");
+        if (success) {
+            return new EconomyResponse(amount, getBalance(player), EconomyResponse.ResponseType.SUCCESS, null);
+        } else {
+            return new EconomyResponse(0, getBalance(player), EconomyResponse.ResponseType.FAILURE, "Failed to deposit.");
+        }
     }
 
     @Override
@@ -107,18 +107,8 @@ public class VaultEconomyAdapter extends AbstractEconomy {
     }
 
     @Override
-    public boolean hasAccount(String playerName, String worldName) {
-        return hasAccount(playerName);
-    }
-
-    @Override
     public double getBalance(String playerName) {
         return getBalance(Bukkit.getOfflinePlayer(playerName));
-    }
-
-    @Override
-    public double getBalance(String playerName, String world) {
-        return getBalance(playerName);
     }
 
     @Override
@@ -127,18 +117,8 @@ public class VaultEconomyAdapter extends AbstractEconomy {
     }
 
     @Override
-    public boolean has(String playerName, String worldName, double amount) {
-        return has(playerName, amount);
-    }
-
-    @Override
     public EconomyResponse withdrawPlayer(String playerName, double amount) {
         return withdrawPlayer(Bukkit.getOfflinePlayer(playerName), amount);
-    }
-
-    @Override
-    public EconomyResponse withdrawPlayer(String playerName, String worldName, double amount) {
-        return withdrawPlayer(playerName, amount);
     }
 
     @Override
@@ -147,25 +127,56 @@ public class VaultEconomyAdapter extends AbstractEconomy {
     }
 
     @Override
-    public EconomyResponse depositPlayer(String playerName, String worldName, double amount) {
-        return depositPlayer(playerName, amount);
-    }
-
-    @Override
     public boolean createPlayerAccount(String playerName) {
         return createPlayerAccount(Bukkit.getOfflinePlayer(playerName));
     }
 
     @Override
-    public boolean createPlayerAccount(String playerName, String worldName) {
-        return createPlayerAccount(playerName);
+    public boolean hasAccount(String playerName, String worldName) {
+        return hasAccount(Bukkit.getOfflinePlayer(playerName));
     }
 
-    // Unsupported Operations
+    @Override
+    public double getBalance(String playerName, String world) {
+        return getBalance(Bukkit.getOfflinePlayer(playerName));
+    }
+
+    @Override
+    public boolean has(String playerName, String worldName, double amount) {
+        return has(Bukkit.getOfflinePlayer(playerName), amount);
+    }
+
+    @Override
+    public EconomyResponse withdrawPlayer(String playerName, String worldName, double amount) {
+        return withdrawPlayer(Bukkit.getOfflinePlayer(playerName), amount);
+    }
+
+    @Override
+    public EconomyResponse depositPlayer(String playerName, String worldName, double amount) {
+        return depositPlayer(Bukkit.getOfflinePlayer(playerName), amount);
+    }
+
+    @Override
+    public boolean createPlayerAccount(String playerName, String worldName) {
+        return createPlayerAccount(Bukkit.getOfflinePlayer(playerName));
+    }
+
+    @Override
+    public EconomyResponse isBankOwner(String name, String playerName) {
+        return new EconomyResponse(0, 0, EconomyResponse.ResponseType.NOT_IMPLEMENTED, "KEC does not support multiple banks.");
+    }
+
+    @Override
+    public EconomyResponse isBankMember(String name, String playerName) {
+        return new EconomyResponse(0, 0, EconomyResponse.ResponseType.NOT_IMPLEMENTED, "KEC does not support multiple banks.");
+    }
+
     @Override
     public EconomyResponse createBank(String name, String player) {
         return new EconomyResponse(0, 0, EconomyResponse.ResponseType.NOT_IMPLEMENTED, "KEC does not support multiple banks.");
     }
+
+    // Unsupported Bank Operations
     @Override
     public EconomyResponse createBank(String name, OfflinePlayer player) {
         return new EconomyResponse(0, 0, EconomyResponse.ResponseType.NOT_IMPLEMENTED, "KEC does not support multiple banks.");
@@ -195,15 +206,7 @@ public class VaultEconomyAdapter extends AbstractEconomy {
         return new EconomyResponse(0, 0, EconomyResponse.ResponseType.NOT_IMPLEMENTED, "KEC does not support multiple banks.");
     }
     @Override
-    public EconomyResponse isBankOwner(String name, String playerName) {
-        return new EconomyResponse(0, 0, EconomyResponse.ResponseType.NOT_IMPLEMENTED, "KEC does not support multiple banks.");
-    }
-    @Override
     public EconomyResponse isBankMember(String name, OfflinePlayer player) {
-        return new EconomyResponse(0, 0, EconomyResponse.ResponseType.NOT_IMPLEMENTED, "KEC does not support multiple banks.");
-    }
-    @Override
-    public EconomyResponse isBankMember(String name, String playerName) {
         return new EconomyResponse(0, 0, EconomyResponse.ResponseType.NOT_IMPLEMENTED, "KEC does not support multiple banks.");
     }
     @Override
@@ -211,15 +214,27 @@ public class VaultEconomyAdapter extends AbstractEconomy {
         return Collections.emptyList();
     }
     @Override
-    public boolean hasAccount(OfflinePlayer player, String worldName) { return hasAccount(player); }
+    public boolean hasAccount(OfflinePlayer player, String worldName) {
+        return hasAccount(player);
+    }
     @Override
-    public double getBalance(OfflinePlayer player, String world) { return getBalance(player); }
+    public double getBalance(OfflinePlayer player, String world) {
+        return getBalance(player);
+    }
     @Override
-    public boolean has(OfflinePlayer player, String worldName, double amount) { return has(player, amount); }
+    public boolean has(OfflinePlayer player, String worldName, double amount) {
+        return has(player, amount);
+    }
     @Override
-    public EconomyResponse withdrawPlayer(OfflinePlayer player, String worldName, double amount) { return withdrawPlayer(player, amount); }
+    public EconomyResponse withdrawPlayer(OfflinePlayer player, String worldName, double amount) {
+        return withdrawPlayer(player, amount);
+    }
     @Override
-    public EconomyResponse depositPlayer(OfflinePlayer player, String worldName, double amount) { return depositPlayer(player, amount); }
+    public EconomyResponse depositPlayer(OfflinePlayer player, String worldName, double amount) {
+        return depositPlayer(player, amount);
+    }
     @Override
-    public boolean createPlayerAccount(OfflinePlayer player, String worldName) { return createPlayerAccount(player); }
+    public boolean createPlayerAccount(OfflinePlayer player, String worldName) {
+        return createPlayerAccount(player);
+    }
 }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,7 +1,7 @@
 name: KartaEmeraldCurrency
 main: com.minekarta.kec.KartaEmeraldCurrencyPlugin
 version: ${version}
-api-version: '1.19'
+api-version: '1.21'
 authors: [MinekartaStudio]
 description: An emerald-based economy plugin with a virtual bank, GUI, and API.
 softdepend: [Vault, PlaceholderAPI]


### PR DESCRIPTION
This commit updates the KartaEmeraldCurrency plugin to be compatible with PaperMC 1.21 and newer.

Key changes include:
- Updated Paper API to 1.21 and Java version to 21.
- Updated Vault API to 1.7.1 (latest available on JitPack).
- Updated the shadow-jar plugin to a version compatible with Gradle 8.8 and Java 21.
- Fixed numerous deprecation warnings in the Vault economy adapter and PlaceholderAPI expansion.
- Refactored and fixed a bug in the VaultEconomyAdapter related to handling economy responses.
- Added Javadocs to the main plugin class and API for better documentation and to reduce build warnings.
- Updated the README.md to reflect the new compatibility, add a missing admin command, and clarify the status of placeholders.

The plugin now compiles successfully against the new APIs. The deprecation warnings from the Vault API itself are still present, as the plugin must implement those methods for compatibility. The leaderboard placeholders in the README have been marked as not yet implemented to reflect the actual state of the code.