### PR TITLE
Fix compiler warnings for deprecation and Javadoc

### DIFF
--- a/src/main/java/com/minekarta/kec/KartaEmeraldCurrencyPlugin.java
+++ b/src/main/java/com/minekarta/kec/KartaEmeraldCurrencyPlugin.java
@@ -26,6 +26,13 @@ import java.util.concurrent.Executor;
  */
 public class KartaEmeraldCurrencyPlugin extends JavaPlugin {
 
+    /**
+     * Constructs a new KartaEmeraldCurrencyPlugin.
+     */
+    public KartaEmeraldCurrencyPlugin() {
+        // Default constructor
+    }
+
     private static KartaEmeraldCurrencyPlugin instance;
 
     private Storage storage;

--- a/src/main/java/com/minekarta/kec/api/event/BankDepositEvent.java
+++ b/src/main/java/com/minekarta/kec/api/event/BankDepositEvent.java
@@ -17,6 +17,12 @@ public class BankDepositEvent extends Event implements Cancellable {
     private final Player player;
     private long amount;
 
+    /**
+     * Constructs a new BankDepositEvent.
+     *
+     * @param player The player depositing.
+     * @param amount The amount being deposited.
+     */
     public BankDepositEvent(@NotNull Player player, long amount) {
         super(false); // This event involves inventory, so it must be synchronous
         this.player = player;
@@ -64,6 +70,10 @@ public class BankDepositEvent extends Event implements Cancellable {
         return handlers;
     }
 
+    /**
+     * Gets the handler list for this event.
+     * @return The handler list.
+     */
     @NotNull
     public static HandlerList getHandlerList() {
         return handlers;

--- a/src/main/java/com/minekarta/kec/api/event/BankWithdrawEvent.java
+++ b/src/main/java/com/minekarta/kec/api/event/BankWithdrawEvent.java
@@ -17,6 +17,12 @@ public class BankWithdrawEvent extends Event implements Cancellable {
     private final Player player;
     private long amount;
 
+    /**
+     * Constructs a new BankWithdrawEvent.
+     *
+     * @param player The player withdrawing.
+     * @param amount The amount being withdrawn.
+     */
     public BankWithdrawEvent(@NotNull Player player, long amount) {
         super(false); // This event involves inventory, so it must be synchronous
         this.player = player;
@@ -64,6 +70,10 @@ public class BankWithdrawEvent extends Event implements Cancellable {
         return handlers;
     }
 
+    /**
+     * Gets the handler list for this event.
+     * @return The handler list.
+     */
     @NotNull
     public static HandlerList getHandlerList() {
         return handlers;

--- a/src/main/java/com/minekarta/kec/api/event/CurrencyBalanceChangeEvent.java
+++ b/src/main/java/com/minekarta/kec/api/event/CurrencyBalanceChangeEvent.java
@@ -21,6 +21,15 @@ public class CurrencyBalanceChangeEvent extends Event implements Cancellable {
     private final long from;
     private long to;
 
+    /**
+     * Constructs a new CurrencyBalanceChangeEvent.
+     *
+     * @param isAsync Whether the event is asynchronous.
+     * @param playerId The UUID of the player.
+     * @param reason The reason for the change.
+     * @param from The original balance.
+     * @param to The new balance.
+     */
     public CurrencyBalanceChangeEvent(boolean isAsync, @NotNull UUID playerId, @NotNull ChangeReason reason, long from, long to) {
         super(isAsync);
         this.playerId = playerId;
@@ -88,6 +97,10 @@ public class CurrencyBalanceChangeEvent extends Event implements Cancellable {
         return handlers;
     }
 
+    /**
+     * Gets the handler list for this event.
+     * @return The handler list.
+     */
     @NotNull
     public static HandlerList getHandlerList() {
         return handlers;
@@ -97,14 +110,41 @@ public class CurrencyBalanceChangeEvent extends Event implements Cancellable {
      * Represents the cause of the balance change.
      */
     public enum ChangeReason {
+        /**
+         * Balance set by an administrator.
+         */
         ADMIN_SET,
+        /**
+         * Balance increased by an administrator.
+         */
         ADMIN_ADD,
+        /**
+         * Balance decreased by an administrator.
+         */
         ADMIN_REMOVE,
+        /**
+         * Balance changed due to a deposit.
+         */
         DEPOSIT,
+        /**
+         * Balance changed due to a withdrawal.
+         */
         WITHDRAW,
+        /**
+         * Balance changed due to sending a transfer.
+         */
         TRANSFER_SEND,
+        /**
+         * Balance changed due to receiving a transfer.
+         */
         TRANSFER_RECEIVE,
+        /**
+         * Balance changed by another plugin via the API.
+         */
         PLUGIN_API,
+        /**
+         * Balance changed for another reason.
+         */
         OTHER
     }
 }

--- a/src/main/java/com/minekarta/kec/api/event/CurrencyTransferEvent.java
+++ b/src/main/java/com/minekarta/kec/api/event/CurrencyTransferEvent.java
@@ -24,6 +24,16 @@ public class CurrencyTransferEvent extends Event implements Cancellable {
     private long amount;
     private long fee;
 
+    /**
+     * Constructs a new CurrencyTransferEvent.
+     *
+     * @param isAsync Whether the event is asynchronous.
+     * @param from The UUID of the sender.
+     * @param to The UUID of the receiver.
+     * @param reason The reason for the transfer.
+     * @param amount The amount to transfer.
+     * @param fee The fee for the transfer.
+     */
     public CurrencyTransferEvent(boolean isAsync, @NotNull UUID from, @NotNull UUID to, @Nullable TransferReason reason, long amount, long fee) {
         super(isAsync);
         this.from = from;
@@ -116,6 +126,10 @@ public class CurrencyTransferEvent extends Event implements Cancellable {
         return handlers;
     }
 
+    /**
+     * Gets the handler list for this event.
+     * @return The handler list.
+     */
     @NotNull
     public static HandlerList getHandlerList() {
         return handlers;

--- a/src/main/java/com/minekarta/kec/api/event/EconomyProviderRegisteredEvent.java
+++ b/src/main/java/com/minekarta/kec/api/event/EconomyProviderRegisteredEvent.java
@@ -13,6 +13,11 @@ public class EconomyProviderRegisteredEvent extends Event {
     private static final HandlerList handlers = new HandlerList();
     private final String economyName;
 
+    /**
+     * Constructs a new EconomyProviderRegisteredEvent.
+     *
+     * @param economyName The name of the economy provider.
+     */
     public EconomyProviderRegisteredEvent(@NotNull String economyName) {
         super(true); // This can be async as it's just a notification
         this.economyName = economyName;
@@ -33,6 +38,10 @@ public class EconomyProviderRegisteredEvent extends Event {
         return handlers;
     }
 
+    /**
+     * Gets the handler list for this event.
+     * @return The handler list.
+     */
     @NotNull
     public static HandlerList getHandlerList() {
         return handlers;

--- a/src/main/java/com/minekarta/kec/command/EmeraldAdminCommand.java
+++ b/src/main/java/com/minekarta/kec/command/EmeraldAdminCommand.java
@@ -18,11 +18,18 @@ import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+/**
+ * Handles the /emeraldadmin command.
+ */
 public class EmeraldAdminCommand implements CommandExecutor, TabCompleter {
 
     private final KartaEmeraldCurrencyPlugin plugin;
     private final KartaEmeraldService service;
 
+    /**
+     * Constructs a new EmeraldAdminCommand.
+     * @param plugin The plugin instance.
+     */
     public EmeraldAdminCommand(KartaEmeraldCurrencyPlugin plugin) {
         this.plugin = plugin;
         this.service = plugin.getService();

--- a/src/main/java/com/minekarta/kec/command/EmeraldCommand.java
+++ b/src/main/java/com/minekarta/kec/command/EmeraldCommand.java
@@ -16,11 +16,18 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
+/**
+ * Handles the /emerald command.
+ */
 public class EmeraldCommand implements CommandExecutor, TabCompleter {
 
     private final KartaEmeraldCurrencyPlugin plugin;
     private final KartaEmeraldService service;
 
+    /**
+     * Constructs a new EmeraldCommand.
+     * @param plugin The plugin instance.
+     */
     public EmeraldCommand(KartaEmeraldCurrencyPlugin plugin) {
         this.plugin = plugin;
         this.service = plugin.getService();

--- a/src/main/java/com/minekarta/kec/gui/AbstractGui.java
+++ b/src/main/java/com/minekarta/kec/gui/AbstractGui.java
@@ -17,19 +17,43 @@ import org.jetbrains.annotations.NotNull;
 import java.util.List;
 import java.util.stream.Collectors;
 
+/**
+ * Represents an abstract GUI screen.
+ */
 public abstract class AbstractGui implements InventoryHolder {
 
+    /**
+     * The plugin instance.
+     */
     protected final KartaEmeraldCurrencyPlugin plugin;
+    /**
+     * The player viewing the GUI.
+     */
     protected final Player player;
+    /**
+     * The inventory for this GUI.
+     */
     protected Inventory inventory;
 
+    /**
+     * Constructs a new AbstractGui.
+     * @param plugin The plugin instance.
+     * @param player The player viewing the GUI.
+     */
     public AbstractGui(KartaEmeraldCurrencyPlugin plugin, Player player) {
         this.plugin = plugin;
         this.player = player;
     }
 
+    /**
+     * Opens the GUI for the player.
+     */
     public abstract void open();
 
+    /**
+     * Handles a click event in the GUI.
+     * @param event The click event.
+     */
     public abstract void handleClick(InventoryClickEvent event);
 
     @Override

--- a/src/main/java/com/minekarta/kec/gui/GuiListener.java
+++ b/src/main/java/com/minekarta/kec/gui/GuiListener.java
@@ -5,8 +5,22 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.inventory.InventoryHolder;
 
+/**
+ * Listener for GUI-related events.
+ */
 public class GuiListener implements Listener {
 
+    /**
+     * Constructs a new GuiListener.
+     */
+    public GuiListener() {
+        // Default constructor
+    }
+
+    /**
+     * Handles clicks within GUI inventories.
+     * @param event The inventory click event.
+     */
     @EventHandler
     public void onInventoryClick(InventoryClickEvent event) {
         InventoryHolder holder = event.getInventory().getHolder();

--- a/src/main/java/com/minekarta/kec/gui/MainGui.java
+++ b/src/main/java/com/minekarta/kec/gui/MainGui.java
@@ -13,8 +13,16 @@ import org.bukkit.inventory.meta.ItemMeta;
 import java.util.List;
 import java.util.stream.Collectors;
 
+/**
+ * The main GUI for the KartaEmeraldCurrency plugin.
+ */
 public class MainGui extends AbstractGui {
 
+    /**
+     * Constructs a new MainGui.
+     * @param plugin The plugin instance.
+     * @param player The player viewing the GUI.
+     */
     public MainGui(KartaEmeraldCurrencyPlugin plugin, Player player) {
         super(plugin, player);
     }

--- a/src/main/java/com/minekarta/kec/placeholder/KecPlaceholderExpansion.java
+++ b/src/main/java/com/minekarta/kec/placeholder/KecPlaceholderExpansion.java
@@ -6,11 +6,18 @@ import me.clip.placeholderapi.expansion.PlaceholderExpansion;
 import org.bukkit.OfflinePlayer;
 import org.jetbrains.annotations.NotNull;
 
+/**
+ * The PlaceholderAPI expansion for KartaEmeraldCurrency.
+ */
 public class KecPlaceholderExpansion extends PlaceholderExpansion {
 
     private final KartaEmeraldCurrencyPlugin plugin;
     private final KartaEmeraldService service;
 
+    /**
+     * Constructs a new KecPlaceholderExpansion.
+     * @param plugin The plugin instance.
+     */
     public KecPlaceholderExpansion(KartaEmeraldCurrencyPlugin plugin) {
         this.plugin = plugin;
         this.service = plugin.getService();

--- a/src/main/java/com/minekarta/kec/service/KartaEmeraldServiceImpl.java
+++ b/src/main/java/com/minekarta/kec/service/KartaEmeraldServiceImpl.java
@@ -24,12 +24,20 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
+/**
+ * The implementation of the KartaEmeraldService.
+ */
 public class KartaEmeraldServiceImpl implements KartaEmeraldService {
 
     private final KartaEmeraldCurrencyPlugin plugin;
     private final Storage storage;
     private final CurrencyFormatter formatter = new Formatter();
 
+    /**
+     * Constructs a new KartaEmeraldServiceImpl.
+     * @param plugin The plugin instance.
+     * @param storage The storage implementation.
+     */
     public KartaEmeraldServiceImpl(KartaEmeraldCurrencyPlugin plugin, Storage storage) {
         this.plugin = plugin;
         this.storage = storage;

--- a/src/main/java/com/minekarta/kec/storage/DatabaseManager.java
+++ b/src/main/java/com/minekarta/kec/storage/DatabaseManager.java
@@ -17,10 +17,27 @@ public class DatabaseManager {
 
     private final HikariDataSource dataSource;
 
+    /**
+     * Enum for the supported storage types.
+     */
     public enum StorageType {
-        SQLITE, MYSQL
+        /**
+         * Use SQLite for data storage.
+         */
+        SQLITE,
+        /**
+         * Use MySQL for data storage.
+         */
+        MYSQL
     }
 
+    /**
+     * Constructs a new DatabaseManager.
+     *
+     * @param type The type of storage to use.
+     * @param dbProps The database properties.
+     * @param dataFolderPath The path to the plugin's data folder.
+     */
     public DatabaseManager(@NotNull StorageType type, @NotNull Properties dbProps, @NotNull Path dataFolderPath) {
         HikariConfig config = new HikariConfig();
 

--- a/src/main/java/com/minekarta/kec/storage/MySqlStorage.java
+++ b/src/main/java/com/minekarta/kec/storage/MySqlStorage.java
@@ -11,6 +11,9 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.function.Supplier;
 
+/**
+ * A MySQL implementation of the {@link Storage} interface.
+ */
 public class MySqlStorage implements Storage {
 
     private final DatabaseManager dbManager;
@@ -38,6 +41,12 @@ public class MySqlStorage implements Storage {
             UPDATE kec_accounts SET balance = balance - ? WHERE uuid = ?;
             """; // A simple update is better here for MySQL
 
+    /**
+     * Constructs a new MySqlStorage.
+     *
+     * @param dbManager The database manager.
+     * @param asyncExecutor The executor for async tasks.
+     */
     public MySqlStorage(DatabaseManager dbManager, Executor asyncExecutor) {
         this.dbManager = dbManager;
         this.asyncExecutor = asyncExecutor;

--- a/src/main/java/com/minekarta/kec/storage/SqliteStorage.java
+++ b/src/main/java/com/minekarta/kec/storage/SqliteStorage.java
@@ -11,6 +11,9 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.function.Supplier;
 
+/**
+ * A SQLite implementation of the {@link Storage} interface.
+ */
 public class SqliteStorage implements Storage {
 
     private final DatabaseManager dbManager;
@@ -39,6 +42,12 @@ public class SqliteStorage implements Storage {
             """;
 
 
+    /**
+     * Constructs a new SqliteStorage.
+     *
+     * @param dbManager The database manager.
+     * @param asyncExecutor The executor for async tasks.
+     */
     public SqliteStorage(DatabaseManager dbManager, Executor asyncExecutor) {
         this.dbManager = dbManager;
         this.asyncExecutor = asyncExecutor;

--- a/src/main/java/com/minekarta/kec/storage/Storage.java
+++ b/src/main/java/com/minekarta/kec/storage/Storage.java
@@ -64,6 +64,7 @@ public interface Storage {
      * Creates an account for a player, usually with a default starting balance.
      *
      * @param uuid The UUID of the player.
+     * @param startingBalance The initial balance for the account.
      * @return A CompletableFuture that completes when the account is created.
      */
     CompletableFuture<Void> createAccount(@NotNull UUID uuid, long startingBalance);

--- a/src/main/java/com/minekarta/kec/util/MessageUtil.java
+++ b/src/main/java/com/minekarta/kec/util/MessageUtil.java
@@ -8,16 +8,36 @@ import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
 import org.bukkit.command.CommandSender;
 import org.bukkit.configuration.file.FileConfiguration;
 
+/**
+ * A utility class for sending messages to players.
+ */
 public class MessageUtil {
 
     private static final MiniMessage miniMessage = MiniMessage.miniMessage();
     private static String prefix = "";
 
+    /**
+     * Private constructor to prevent instantiation.
+     */
+    private MessageUtil() {
+        // Utility class
+    }
+
+    /**
+     * Loads the message prefix from the configuration.
+     * @param plugin The plugin instance.
+     */
     public static void load(KartaEmeraldCurrencyPlugin plugin) {
         FileConfiguration messages = plugin.getMessagesConfig();
         prefix = messages.getString("prefix", "<dark_gray>[<green>KEC</green>]<reset> ");
     }
 
+    /**
+     * Sends a message from messages.yml to a target.
+     * @param target The target to send the message to.
+     * @param messageKey The key of the message in messages.yml.
+     * @param resolvers Placeholders to use in the message.
+     */
     public static void sendMessage(CommandSender target, String messageKey, TagResolver... resolvers) {
         KartaEmeraldCurrencyPlugin plugin = KartaEmeraldCurrencyPlugin.getInstance();
         String message = plugin.getMessagesConfig().getString(messageKey, "<red>Unknown message key: " + messageKey + "</red>");
@@ -26,15 +46,33 @@ public class MessageUtil {
         target.sendMessage(parsedMessage);
     }
 
+    /**
+     * Sends a raw string message to a target.
+     * @param target The target to send the message to.
+     * @param message The message to send.
+     * @param resolvers Placeholders to use in the message.
+     */
     public static void sendRawMessage(CommandSender target, String message, TagResolver... resolvers) {
         Component parsedMessage = miniMessage.deserialize(message, resolvers);
         target.sendMessage(parsedMessage);
     }
 
+    /**
+     * Creates a placeholder for use in messages.
+     * @param key The placeholder key.
+     * @param value The placeholder value.
+     * @return The created TagResolver.
+     */
     public static TagResolver placeholder(String key, String value) {
         return Placeholder.unparsed(key, value);
     }
 
+    /**
+     * Creates a placeholder for use in messages.
+     * @param key The placeholder key.
+     * @param value The placeholder value.
+     * @return The created TagResolver.
+     */
     public static TagResolver placeholder(String key, Object value) {
         return Placeholder.unparsed(key, String.valueOf(value));
     }

--- a/src/main/java/com/minekarta/kec/vault/VaultEconomyAdapter.java
+++ b/src/main/java/com/minekarta/kec/vault/VaultEconomyAdapter.java
@@ -101,76 +101,91 @@ public class VaultEconomyAdapter extends AbstractEconomy {
         return true;
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     public boolean hasAccount(String playerName) {
         return hasAccount(Bukkit.getOfflinePlayer(playerName));
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     public double getBalance(String playerName) {
         return getBalance(Bukkit.getOfflinePlayer(playerName));
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     public boolean has(String playerName, double amount) {
         return has(Bukkit.getOfflinePlayer(playerName), amount);
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     public EconomyResponse withdrawPlayer(String playerName, double amount) {
         return withdrawPlayer(Bukkit.getOfflinePlayer(playerName), amount);
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     public EconomyResponse depositPlayer(String playerName, double amount) {
         return depositPlayer(Bukkit.getOfflinePlayer(playerName), amount);
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     public boolean createPlayerAccount(String playerName) {
         return createPlayerAccount(Bukkit.getOfflinePlayer(playerName));
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     public boolean hasAccount(String playerName, String worldName) {
         return hasAccount(Bukkit.getOfflinePlayer(playerName));
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     public double getBalance(String playerName, String world) {
         return getBalance(Bukkit.getOfflinePlayer(playerName));
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     public boolean has(String playerName, String worldName, double amount) {
         return has(Bukkit.getOfflinePlayer(playerName), amount);
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     public EconomyResponse withdrawPlayer(String playerName, String worldName, double amount) {
         return withdrawPlayer(Bukkit.getOfflinePlayer(playerName), amount);
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     public EconomyResponse depositPlayer(String playerName, String worldName, double amount) {
         return depositPlayer(Bukkit.getOfflinePlayer(playerName), amount);
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     public boolean createPlayerAccount(String playerName, String worldName) {
         return createPlayerAccount(Bukkit.getOfflinePlayer(playerName));
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     public EconomyResponse isBankOwner(String name, String playerName) {
         return new EconomyResponse(0, 0, EconomyResponse.ResponseType.NOT_IMPLEMENTED, "KEC does not support multiple banks.");
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     public EconomyResponse isBankMember(String name, String playerName) {
         return new EconomyResponse(0, 0, EconomyResponse.ResponseType.NOT_IMPLEMENTED, "KEC does not support multiple banks.");
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     public EconomyResponse createBank(String name, String player) {
         return new EconomyResponse(0, 0, EconomyResponse.ResponseType.NOT_IMPLEMENTED, "KEC does not support multiple banks.");


### PR DESCRIPTION
This commit addresses two types of warnings that appear during compilation:

1.  **Deprecation Warnings:**
    - Suppressed deprecation warnings in `VaultEconomyAdapter.java` by adding the `@SuppressWarnings("deprecation")` annotation to all methods that override deprecated methods from Vault's `AbstractEconomy` class. This resolves the warnings without breaking compatibility.

2.  **Javadoc Warnings:**
    - Added missing Javadoc comments to numerous classes, methods, constructors, and enums across the codebase. This resolves the "no comment" warnings generated by the `javadoc` task and improves code documentation.