### PR TITLE
This commit replaces the SQLite database dependency with H2 to reduce…

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,7 +36,7 @@ dependencies {
     // Implementation Dependencies (to be shaded)
     implementation("com.zaxxer:HikariCP:${properties.getProperty("hikariVersion")}")
     implementation("net.kyori:adventure-text-minimessage:${properties.getProperty("miniMessageVersion")}")
-    implementation("org.xerial:sqlite-jdbc:${properties.getProperty("sqliteDriverVersion")}")
+    implementation("com.h2database:h2:${properties.getProperty("h2DriverVersion")}")
 }
 
 tasks {
@@ -52,7 +52,7 @@ tasks {
         archiveClassifier.set("") // Produce a single jar without the '-all' suffix
         relocate("com.zaxxer.hikari", "com.minekarta.kec.libs.hikaricp")
         relocate("net.kyori.adventure", "com.minekarta.kec.libs.adventure")
-        relocate("org.sqlite", "com.minekarta.kec.libs.sqlite")
+        relocate("org.h2", "com.minekarta.kec.libs.h2")
 
         // Minimize the JAR file by removing unnecessary files
         minimize()

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,5 +9,5 @@ vaultApiVersion=1.7.1
 placeholderApiVersion=2.11.6
 hikariVersion=5.1.0
 miniMessageVersion=4.17.0
-sqliteDriverVersion=3.46.0.0
+h2DriverVersion=2.3.232
 shadowPluginVersion=8.1.1

--- a/src/main/java/com/minekarta/kec/KartaEmeraldCurrencyPlugin.java
+++ b/src/main/java/com/minekarta/kec/KartaEmeraldCurrencyPlugin.java
@@ -7,7 +7,7 @@ import com.minekarta.kec.service.KartaEmeraldServiceImpl;
 import com.minekarta.kec.storage.DatabaseManager;
 import com.minekarta.kec.util.MessageUtil;
 import com.minekarta.kec.storage.MySqlStorage;
-import com.minekarta.kec.storage.SqliteStorage;
+import com.minekarta.kec.storage.H2Storage;
 import com.minekarta.kec.storage.Storage;
 import org.bukkit.Bukkit;
 import org.bukkit.configuration.file.FileConfiguration;
@@ -103,20 +103,20 @@ public class KartaEmeraldCurrencyPlugin extends JavaPlugin {
     }
 
     private boolean setupStorage() {
-        String storageTypeStr = databaseConfig.getString("storage.type", "SQLITE").toUpperCase();
+        String storageTypeStr = databaseConfig.getString("storage.type", "H2").toUpperCase();
         DatabaseManager.StorageType storageType;
         try {
             storageType = DatabaseManager.StorageType.valueOf(storageTypeStr);
         } catch (IllegalArgumentException e) {
-            getLogger().severe("Invalid storage type '" + storageTypeStr + "' in database.yml. Defaulting to SQLITE.");
-            storageType = DatabaseManager.StorageType.SQLITE;
+            getLogger().severe("Invalid storage type '" + storageTypeStr + "' in database.yml. Defaulting to H2.");
+            storageType = DatabaseManager.StorageType.H2;
         }
 
         Properties dbProps = new Properties();
         if (storageType == DatabaseManager.StorageType.MYSQL) {
             databaseConfig.getConfigurationSection("mysql").getValues(true).forEach((key, value) -> dbProps.setProperty("mysql." + key, value.toString()));
-        } else {
-            databaseConfig.getConfigurationSection("sqlite").getValues(true).forEach((key, value) -> dbProps.setProperty("sqlite." + key, value.toString()));
+        } else { // H2
+            databaseConfig.getConfigurationSection("h2").getValues(true).forEach((key, value) -> dbProps.setProperty("h2." + key, value.toString()));
         }
 
         try {
@@ -125,8 +125,8 @@ public class KartaEmeraldCurrencyPlugin extends JavaPlugin {
 
             if (storageType == DatabaseManager.StorageType.MYSQL) {
                 this.storage = new MySqlStorage(databaseManager, asyncExecutor);
-            } else {
-                this.storage = new SqliteStorage(databaseManager, asyncExecutor);
+            } else { // H2
+                this.storage = new H2Storage(databaseManager, asyncExecutor);
             }
 
             this.storage.initialize().join(); // Wait for table creation on startup

--- a/src/main/java/com/minekarta/kec/storage/DatabaseManager.java
+++ b/src/main/java/com/minekarta/kec/storage/DatabaseManager.java
@@ -22,9 +22,9 @@ public class DatabaseManager {
      */
     public enum StorageType {
         /**
-         * Use SQLite for data storage.
+         * Use H2 for data storage.
          */
-        SQLITE,
+        H2,
         /**
          * Use MySQL for data storage.
          */
@@ -42,13 +42,13 @@ public class DatabaseManager {
         HikariConfig config = new HikariConfig();
 
         switch (type) {
-            case SQLITE:
-                String dbFileName = dbProps.getProperty("sqlite.file", "kec-data.db");
+            case H2:
+                String dbFileName = dbProps.getProperty("h2.file", "kec-data.db");
                 File dbFile = dataFolderPath.resolve(dbFileName).toFile();
                 if (!dbFile.getParentFile().exists()) {
                     dbFile.getParentFile().mkdirs();
                 }
-                config.setJdbcUrl("jdbc:sqlite:" + dbFile.getAbsolutePath());
+                config.setJdbcUrl("jdbc:h2:" + dbFile.getAbsolutePath());
                 break;
 
             case MYSQL:

--- a/src/main/resources/database.yml
+++ b/src/main/resources/database.yml
@@ -1,13 +1,13 @@
 # KartaEmeraldCurrency - Database Configuration
 
 # The type of storage to use for player data.
-# Supported types: SQLITE, MYSQL
+# Supported types: H2, MYSQL
 storage:
-  type: SQLITE
+  type: H2
 
-# Configuration for SQLite.
+# Configuration for H2.
 # This is a file-based database, ideal for small to medium servers.
-sqlite:
+h2:
   # The name of the database file. It will be created in the plugin's data folder.
   file: "kec-data.db"
 


### PR DESCRIPTION
… the overall plugin size.

Changes include:
- Updated `build.gradle.kts` and `gradle.properties` to use the H2 dependency instead of `sqlite-jdbc`.
- Replaced the `SqliteStorage` implementation with `H2Storage`, updating SQL queries to be compatible with H2 (using `MERGE` instead of `ON CONFLICT`).
- Updated the main plugin class and `DatabaseManager` to handle H2 as a storage type.
- Changed the default configuration in `database.yml` to use H2.