### PR TITLE
Fix: Explicitly set H2 driver class name

### DIFF
--- a/src/main/java/com/minekarta/kec/storage/DatabaseManager.java
+++ b/src/main/java/com/minekarta/kec/storage/DatabaseManager.java
@@ -48,6 +48,7 @@ public class DatabaseManager {
                 if (!dbFile.getParentFile().exists()) {
                     dbFile.getParentFile().mkdirs();
                 }
+                config.setDriverClassName("com.minekarta.kec.libs.h2.Driver");
                 config.setJdbcUrl("jdbc:h2:" + dbFile.getAbsolutePath());
                 break;
 


### PR DESCRIPTION
The plugin was failing to connect to the H2 database because the JDBC driver could not be found after being relocated by the shadow plugin. This change explicitly sets the relocated driver class name (`com.minekarta.kec.libs.h2.Driver`) in the HikariCP configuration, allowing the connection to be established correctly.