### PR TITLE
Fix: Remove minimize() to prevent stripping H2 driver

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -53,9 +53,6 @@ tasks {
         relocate("com.zaxxer.hikari", "com.minekarta.kec.libs.hikaricp")
         relocate("net.kyori.adventure", "com.minekarta.kec.libs.adventure")
         relocate("org.h2", "com.minekarta.kec.libs.h2")
-
-        // Minimize the JAR file by removing unnecessary files
-        minimize()
     }
 
     // Set shadowJar as the default build task

--- a/src/main/java/com/minekarta/kec/storage/DatabaseManager.java
+++ b/src/main/java/com/minekarta/kec/storage/DatabaseManager.java
@@ -48,6 +48,7 @@ public class DatabaseManager {
                 if (!dbFile.getParentFile().exists()) {
                     dbFile.getParentFile().mkdirs();
                 }
+                config.setDriverClassName("com.minekarta.kec.libs.h2.Driver");
                 config.setJdbcUrl("jdbc:h2:" + dbFile.getAbsolutePath());
                 break;
 


### PR DESCRIPTION
This commit resolves the `ClassNotFoundException` for the H2 driver by removing the `minimize()` call from the `shadowJar` task in the `build.gradle.kts` file.

The `minimize()` function was too aggressive and was stripping out the H2 JDBC driver classes because it couldn't detect a direct, compile-time usage, leading to a `Failed to load driver class` error at runtime.

Additionally, the explicit setting of the relocated driver class name in `DatabaseManager.java` is retained to ensure HikariCP can reliably find the driver after it has been relocated.