### PR TITLE
fix(database): resolve startup hang during initialization

### DIFF
--- a/src/main/java/com/minekarta/kec/KartaEmeraldCurrencyPlugin.java
+++ b/src/main/java/com/minekarta/kec/KartaEmeraldCurrencyPlugin.java
@@ -129,7 +129,7 @@ public class KartaEmeraldCurrencyPlugin extends JavaPlugin {
                 this.storage = new H2Storage(databaseManager, asyncExecutor);
             }
 
-            this.storage.initialize().join(); // Wait for table creation on startup
+            this.storage.initialize(); // Create tables on startup
             getLogger().info("Successfully connected to " + storageType + " database.");
             return true;
         } catch (Exception e) {

--- a/src/main/java/com/minekarta/kec/storage/DatabaseManager.java
+++ b/src/main/java/com/minekarta/kec/storage/DatabaseManager.java
@@ -48,8 +48,14 @@ public class DatabaseManager {
                 if (!dbFile.getParentFile().exists()) {
                     dbFile.getParentFile().mkdirs();
                 }
+                config.setPoolName("KartaEmerald-H2-Pool");
                 config.setDriverClassName("com.minekarta.kec.libs.h2.Driver");
-                config.setJdbcUrl("jdbc:h2:" + dbFile.getAbsolutePath());
+                // AUTO_SERVER=TRUE allows multiple connections within the same JVM, preventing file lock issues.
+                config.setJdbcUrl("jdbc:h2:" + dbFile.getAbsolutePath() + ";AUTO_SERVER=TRUE");
+
+                // Sensible pool settings for H2
+                config.setMaximumPoolSize(2);
+                config.setConnectionTimeout(TimeUnit.SECONDS.toMillis(10));
                 break;
 
             case MYSQL:

--- a/src/main/java/com/minekarta/kec/storage/H2Storage.java
+++ b/src/main/java/com/minekarta/kec/storage/H2Storage.java
@@ -66,15 +66,14 @@ public class H2Storage implements Storage {
     }
 
     @Override
-    public CompletableFuture<Void> initialize() {
-        return runAsync(() -> {
-            try (Connection conn = dbManager.getDataSource().getConnection();
-                 PreparedStatement ps = conn.prepareStatement(CREATE_ACCOUNTS_TABLE)) {
-                ps.execute();
-            } catch (SQLException e) {
-                throw new RuntimeException("Failed to initialize H2 database", e);
-            }
-        });
+    public void initialize() {
+        // This must run synchronously on startup to ensure tables are ready.
+        try (Connection conn = dbManager.getDataSource().getConnection();
+             PreparedStatement ps = conn.prepareStatement(CREATE_ACCOUNTS_TABLE)) {
+            ps.execute();
+        } catch (SQLException e) {
+            throw new RuntimeException("Failed to initialize H2 database", e);
+        }
     }
 
     @Override

--- a/src/main/java/com/minekarta/kec/storage/MySqlStorage.java
+++ b/src/main/java/com/minekarta/kec/storage/MySqlStorage.java
@@ -61,15 +61,14 @@ public class MySqlStorage implements Storage {
     }
 
     @Override
-    public CompletableFuture<Void> initialize() {
-        return runAsync(() -> {
-            try (Connection conn = dbManager.getDataSource().getConnection();
-                 PreparedStatement ps = conn.prepareStatement(CREATE_ACCOUNTS_TABLE)) {
-                ps.execute();
-            } catch (SQLException e) {
-                throw new RuntimeException("Failed to initialize MySQL database", e);
-            }
-        });
+    public void initialize() {
+        // This must run synchronously on startup to ensure tables are ready.
+        try (Connection conn = dbManager.getDataSource().getConnection();
+             PreparedStatement ps = conn.prepareStatement(CREATE_ACCOUNTS_TABLE)) {
+            ps.execute();
+        } catch (SQLException e) {
+            throw new RuntimeException("Failed to initialize MySQL database", e);
+        }
     }
 
     @Override

--- a/src/main/java/com/minekarta/kec/storage/Storage.java
+++ b/src/main/java/com/minekarta/kec/storage/Storage.java
@@ -13,10 +13,9 @@ public interface Storage {
 
     /**
      * Initializes the storage backend. This can include creating tables if they don't exist.
-     *
-     * @return A CompletableFuture that completes when initialization is done.
+     * This method is expected to be called synchronously on startup.
      */
-    CompletableFuture<Void> initialize();
+    void initialize();
 
     /**
      * Closes any connections and cleans up resources used by the storage backend.


### PR DESCRIPTION
The plugin was getting stuck on startup due to a deadlock in the database initialization process.

The main server thread was calling `storage.initialize().join()`, blocking until the initialization was complete. The `initialize` method, however, was submitting the database query to an asynchronous task.

When using an embedded H2 database, the initial connection from the HikariCP pool could lock the database file. The async task would then block waiting to acquire a connection, while the main thread was blocked waiting for the async task, resulting in a deadlock.

This commit resolves the issue by:
1. Making the `Storage.initialize()` method and its implementations (`H2Storage`, `MySqlStorage`) synchronous. This removes the `CompletableFuture` and the deadlock-causing thread interaction.
2. Updating the `KartaEmeraldCurrencyPlugin` to call the new synchronous method without `.join()`.
3. Improving the H2 database configuration in `DatabaseManager` by:
   - Appending `;AUTO_SERVER=TRUE` to the JDBC URL to mitigate file locking issues.
   - Adding sensible default pool settings (pool size, timeout) for H2.