### PR TITLE
fix(plugin): ensure proper async event dispatch and synchronous db init

### DIFF
--- a/src/main/java/com/minekarta/kec/KartaEmeraldCurrencyPlugin.java
+++ b/src/main/java/com/minekarta/kec/KartaEmeraldCurrencyPlugin.java
@@ -129,7 +129,7 @@ public class KartaEmeraldCurrencyPlugin extends JavaPlugin {
                 this.storage = new H2Storage(databaseManager, asyncExecutor);
             }
 
-            this.storage.initialize().join(); // Wait for table creation on startup
+            this.storage.initialize(); // Create tables on startup
             getLogger().info("Successfully connected to " + storageType + " database.");
             return true;
         } catch (Exception e) {
@@ -146,8 +146,10 @@ public class KartaEmeraldCurrencyPlugin extends JavaPlugin {
             Bukkit.getServicesManager().register(net.milkbowl.vault.economy.Economy.class, vaultAdapter, this, ServicePriority.High);
             getLogger().info("Successfully hooked into Vault.");
 
-            // Fire event for other plugins
-            Bukkit.getPluginManager().callEvent(new com.minekarta.kec.api.event.EconomyProviderRegisteredEvent(vaultAdapter.getName()));
+            // Fire event for other plugins, required by Paper to be async.
+            Bukkit.getScheduler().runTaskAsynchronously(this, () -> {
+                Bukkit.getPluginManager().callEvent(new com.minekarta.kec.api.event.EconomyProviderRegisteredEvent(vaultAdapter.getName()));
+            });
         } else {
             getLogger().warning("Vault not found. Economy features will be limited.");
         }

--- a/src/main/java/com/minekarta/kec/storage/DatabaseManager.java
+++ b/src/main/java/com/minekarta/kec/storage/DatabaseManager.java
@@ -48,8 +48,14 @@ public class DatabaseManager {
                 if (!dbFile.getParentFile().exists()) {
                     dbFile.getParentFile().mkdirs();
                 }
+                config.setPoolName("KartaEmerald-H2-Pool");
                 config.setDriverClassName("com.minekarta.kec.libs.h2.Driver");
-                config.setJdbcUrl("jdbc:h2:" + dbFile.getAbsolutePath());
+                // AUTO_SERVER=TRUE allows multiple connections within the same JVM, preventing file lock issues.
+                config.setJdbcUrl("jdbc:h2:" + dbFile.getAbsolutePath() + ";AUTO_SERVER=TRUE");
+
+                // Sensible pool settings for H2
+                config.setMaximumPoolSize(2);
+                config.setConnectionTimeout(TimeUnit.SECONDS.toMillis(10));
                 break;
 
             case MYSQL:

--- a/src/main/java/com/minekarta/kec/storage/H2Storage.java
+++ b/src/main/java/com/minekarta/kec/storage/H2Storage.java
@@ -66,15 +66,14 @@ public class H2Storage implements Storage {
     }
 
     @Override
-    public CompletableFuture<Void> initialize() {
-        return runAsync(() -> {
-            try (Connection conn = dbManager.getDataSource().getConnection();
-                 PreparedStatement ps = conn.prepareStatement(CREATE_ACCOUNTS_TABLE)) {
-                ps.execute();
-            } catch (SQLException e) {
-                throw new RuntimeException("Failed to initialize H2 database", e);
-            }
-        });
+    public void initialize() {
+        // This must run synchronously on startup to ensure tables are ready.
+        try (Connection conn = dbManager.getDataSource().getConnection();
+             PreparedStatement ps = conn.prepareStatement(CREATE_ACCOUNTS_TABLE)) {
+            ps.execute();
+        } catch (SQLException e) {
+            throw new RuntimeException("Failed to initialize H2 database", e);
+        }
     }
 
     @Override

--- a/src/main/java/com/minekarta/kec/storage/MySqlStorage.java
+++ b/src/main/java/com/minekarta/kec/storage/MySqlStorage.java
@@ -61,15 +61,14 @@ public class MySqlStorage implements Storage {
     }
 
     @Override
-    public CompletableFuture<Void> initialize() {
-        return runAsync(() -> {
-            try (Connection conn = dbManager.getDataSource().getConnection();
-                 PreparedStatement ps = conn.prepareStatement(CREATE_ACCOUNTS_TABLE)) {
-                ps.execute();
-            } catch (SQLException e) {
-                throw new RuntimeException("Failed to initialize MySQL database", e);
-            }
-        });
+    public void initialize() {
+        // This must run synchronously on startup to ensure tables are ready.
+        try (Connection conn = dbManager.getDataSource().getConnection();
+             PreparedStatement ps = conn.prepareStatement(CREATE_ACCOUNTS_TABLE)) {
+            ps.execute();
+        } catch (SQLException e) {
+            throw new RuntimeException("Failed to initialize MySQL database", e);
+        }
     }
 
     @Override

--- a/src/main/java/com/minekarta/kec/storage/Storage.java
+++ b/src/main/java/com/minekarta/kec/storage/Storage.java
@@ -13,10 +13,9 @@ public interface Storage {
 
     /**
      * Initializes the storage backend. This can include creating tables if they don't exist.
-     *
-     * @return A CompletableFuture that completes when initialization is done.
+     * This method is expected to be called synchronously on startup.
      */
-    CompletableFuture<Void> initialize();
+    void initialize();
 
     /**
      * Closes any connections and cleans up resources used by the storage backend.


### PR DESCRIPTION
This commit addresses two issues that occurred during plugin startup:

1.  **Resolves `IllegalStateException` from Paper:** The `EconomyProviderRegisteredEvent` was being fired from the main server thread. The Paper API requires this specific event to be dispatched asynchronously. The fix wraps the `callEvent` in a `runTaskAsynchronously` block to comply with this requirement.

2.  **Re-establishes Synchronous Database Initialization:** An earlier change made the database initialization asynchronous to solve a hang. However, that approach was flawed and caused the above `IllegalStateException`. This commit reverts the database initialization to be a simple, synchronous operation on startup. This is a more robust and straightforward pattern for creating database tables and avoids the deadlock that caused the original hang, without introducing threading issues into the event system.

    - `Storage.initialize()` is now `void` and runs synchronously.
    - The call in the main plugin class is updated accordingly.
    - H2 connection settings are improved with `AUTO_SERVER=TRUE` and explicit pool settings to prevent file locking and improve stability.