### PR TITLE
fix: resolve all startup and command execution errors

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,10 +32,10 @@ dependencies {
     compileOnly("com.github.milkbowl:VaultAPI:${properties.getProperty("vaultApiVersion")}")
     compileOnly("me.clip:placeholderapi:${properties.getProperty("placeholderApiVersion")}")
     compileOnly("mysql:mysql-connector-java:8.0.33") // For compiling against, not for bundling
+    compileOnly("net.kyori:adventure-text-minimessage:${properties.getProperty("miniMessageVersion")}")
 
     // Implementation Dependencies (to be shaded)
     implementation("com.zaxxer:HikariCP:${properties.getProperty("hikariVersion")}")
-    implementation("net.kyori:adventure-text-minimessage:${properties.getProperty("miniMessageVersion")}")
     implementation("com.h2database:h2:${properties.getProperty("h2DriverVersion")}")
 }
 
@@ -51,7 +51,6 @@ tasks {
     shadowJar {
         archiveClassifier.set("") // Produce a single jar without the '-all' suffix
         relocate("com.zaxxer.hikari", "com.minekarta.kec.libs.hikaricp")
-        relocate("net.kyori.adventure", "com.minekarta.kec.libs.adventure")
         relocate("org.h2", "com.minekarta.kec.libs.h2")
     }
 

--- a/src/main/java/com/minekarta/kec/KartaEmeraldCurrencyPlugin.java
+++ b/src/main/java/com/minekarta/kec/KartaEmeraldCurrencyPlugin.java
@@ -129,7 +129,7 @@ public class KartaEmeraldCurrencyPlugin extends JavaPlugin {
                 this.storage = new H2Storage(databaseManager, asyncExecutor);
             }
 
-            this.storage.initialize().join(); // Wait for table creation on startup
+            this.storage.initialize(); // Create tables on startup
             getLogger().info("Successfully connected to " + storageType + " database.");
             return true;
         } catch (Exception e) {
@@ -146,8 +146,10 @@ public class KartaEmeraldCurrencyPlugin extends JavaPlugin {
             Bukkit.getServicesManager().register(net.milkbowl.vault.economy.Economy.class, vaultAdapter, this, ServicePriority.High);
             getLogger().info("Successfully hooked into Vault.");
 
-            // Fire event for other plugins
-            Bukkit.getPluginManager().callEvent(new com.minekarta.kec.api.event.EconomyProviderRegisteredEvent(vaultAdapter.getName()));
+            // Fire event for other plugins, required by Paper to be async.
+            Bukkit.getScheduler().runTaskAsynchronously(this, () -> {
+                Bukkit.getPluginManager().callEvent(new com.minekarta.kec.api.event.EconomyProviderRegisteredEvent(vaultAdapter.getName()));
+            });
         } else {
             getLogger().warning("Vault not found. Economy features will be limited.");
         }

--- a/src/main/java/com/minekarta/kec/storage/DatabaseManager.java
+++ b/src/main/java/com/minekarta/kec/storage/DatabaseManager.java
@@ -48,8 +48,14 @@ public class DatabaseManager {
                 if (!dbFile.getParentFile().exists()) {
                     dbFile.getParentFile().mkdirs();
                 }
+                config.setPoolName("KartaEmerald-H2-Pool");
                 config.setDriverClassName("com.minekarta.kec.libs.h2.Driver");
-                config.setJdbcUrl("jdbc:h2:" + dbFile.getAbsolutePath());
+                // AUTO_SERVER=TRUE allows multiple connections within the same JVM, preventing file lock issues.
+                config.setJdbcUrl("jdbc:h2:" + dbFile.getAbsolutePath() + ";AUTO_SERVER=TRUE");
+
+                // Sensible pool settings for H2
+                config.setMaximumPoolSize(2);
+                config.setConnectionTimeout(TimeUnit.SECONDS.toMillis(10));
                 break;
 
             case MYSQL:

--- a/src/main/java/com/minekarta/kec/storage/H2Storage.java
+++ b/src/main/java/com/minekarta/kec/storage/H2Storage.java
@@ -66,15 +66,14 @@ public class H2Storage implements Storage {
     }
 
     @Override
-    public CompletableFuture<Void> initialize() {
-        return runAsync(() -> {
-            try (Connection conn = dbManager.getDataSource().getConnection();
-                 PreparedStatement ps = conn.prepareStatement(CREATE_ACCOUNTS_TABLE)) {
-                ps.execute();
-            } catch (SQLException e) {
-                throw new RuntimeException("Failed to initialize H2 database", e);
-            }
-        });
+    public void initialize() {
+        // This must run synchronously on startup to ensure tables are ready.
+        try (Connection conn = dbManager.getDataSource().getConnection();
+             PreparedStatement ps = conn.prepareStatement(CREATE_ACCOUNTS_TABLE)) {
+            ps.execute();
+        } catch (SQLException e) {
+            throw new RuntimeException("Failed to initialize H2 database", e);
+        }
     }
 
     @Override

--- a/src/main/java/com/minekarta/kec/storage/MySqlStorage.java
+++ b/src/main/java/com/minekarta/kec/storage/MySqlStorage.java
@@ -61,15 +61,14 @@ public class MySqlStorage implements Storage {
     }
 
     @Override
-    public CompletableFuture<Void> initialize() {
-        return runAsync(() -> {
-            try (Connection conn = dbManager.getDataSource().getConnection();
-                 PreparedStatement ps = conn.prepareStatement(CREATE_ACCOUNTS_TABLE)) {
-                ps.execute();
-            } catch (SQLException e) {
-                throw new RuntimeException("Failed to initialize MySQL database", e);
-            }
-        });
+    public void initialize() {
+        // This must run synchronously on startup to ensure tables are ready.
+        try (Connection conn = dbManager.getDataSource().getConnection();
+             PreparedStatement ps = conn.prepareStatement(CREATE_ACCOUNTS_TABLE)) {
+            ps.execute();
+        } catch (SQLException e) {
+            throw new RuntimeException("Failed to initialize MySQL database", e);
+        }
     }
 
     @Override

--- a/src/main/java/com/minekarta/kec/storage/Storage.java
+++ b/src/main/java/com/minekarta/kec/storage/Storage.java
@@ -13,10 +13,9 @@ public interface Storage {
 
     /**
      * Initializes the storage backend. This can include creating tables if they don't exist.
-     *
-     * @return A CompletableFuture that completes when initialization is done.
+     * This method is expected to be called synchronously on startup.
      */
-    CompletableFuture<Void> initialize();
+    void initialize();
 
     /**
      * Closes any connections and cleans up resources used by the storage backend.


### PR DESCRIPTION
This commit provides a comprehensive fix for a series of cascading errors that occurred during plugin startup and command execution.

The following issues are resolved:
1.  **Server Hang on Startup:** A deadlock during database initialization was resolved by making the `initialize()` method synchronous. The H2 database configuration was also improved with `AUTO_SERVER=TRUE` and explicit pool settings to prevent file locking and improve stability.

2.  **`IllegalStateException` on Enable:** An event (`EconomyProviderRegisteredEvent`) was being fired on the main server thread, which is disallowed by the Paper API. This has been fixed by dispatching the event asynchronously.

3.  **`NoSuchMethodError` on Command Execution:** The plugin was shading the Adventure library, causing a conflict with the version provided by the Paper server. This was fixed by changing the dependency to `compileOnly` and removing the relocation rule from the build script, so the plugin now uses the server-provided library.