### PR TITLE
Refactor GUI item creation and fix lore rendering

### DIFF
--- a/src/main/java/com/minekarta/kec/gui/AbstractGui.java
+++ b/src/main/java/com/minekarta/kec/gui/AbstractGui.java
@@ -3,6 +3,7 @@ package com.minekarta.kec.gui;
 import com.minekarta.kec.KartaEmeraldCurrencyPlugin;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.minimessage.MiniMessage;
+import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.configuration.ConfigurationSection;
@@ -67,6 +68,10 @@ public abstract class AbstractGui implements InventoryHolder {
     }
 
     protected ItemStack createItem(ConfigurationSection itemConfig) {
+        return createItem(itemConfig, TagResolver.empty());
+    }
+
+    protected ItemStack createItem(ConfigurationSection itemConfig, TagResolver resolvers) {
         if (itemConfig == null) return null;
 
         Material material = Material.matchMaterial(itemConfig.getString("material", "STONE"));
@@ -78,13 +83,15 @@ public abstract class AbstractGui implements InventoryHolder {
         if (meta != null) {
             String name = itemConfig.getString("name", "");
             if (!name.isEmpty()) {
-                meta.displayName(MiniMessage.miniMessage().deserialize(name));
+                // To prevent italics, we must deserialize with a tag resolver that includes the player's name.
+                // However, since we don't have the player here, we will just have to do it in the GUI class.
+                meta.displayName(MiniMessage.miniMessage().deserialize(name, resolvers));
             }
 
             List<String> loreLines = itemConfig.getStringList("lore");
             if (!loreLines.isEmpty()) {
                 List<Component> lore = loreLines.stream()
-                        .map(line -> MiniMessage.miniMessage().deserialize(line))
+                        .map(line -> MiniMessage.miniMessage().deserialize("<italic:false>" + line, resolvers))
                         .collect(Collectors.toList());
                 meta.lore(lore);
             }

--- a/src/main/java/com/minekarta/kec/gui/BankGui.java
+++ b/src/main/java/com/minekarta/kec/gui/BankGui.java
@@ -8,10 +8,6 @@ import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.inventory.meta.ItemMeta;
-
-import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * The bank GUI for depositing and withdrawing emeralds.
@@ -119,24 +115,4 @@ public class BankGui extends AbstractGui {
         });
     }
 
-    // Override createItem to handle placeholders
-    private ItemStack createItem(ConfigurationSection itemConfig, TagResolver resolvers) {
-        ItemStack item = super.createItem(itemConfig);
-        if (item == null) return null;
-
-        ItemMeta meta = item.getItemMeta();
-        if (meta != null) {
-            if (meta.hasDisplayName()) {
-                meta.displayName(MiniMessage.miniMessage().deserialize(MiniMessage.miniMessage().serialize(meta.displayName()), resolvers));
-            }
-            if (meta.hasLore()) {
-                List<String> loreLines = itemConfig.getStringList("lore");
-                meta.lore(loreLines.stream()
-                        .map(line -> MiniMessage.miniMessage().deserialize(line, resolvers))
-                        .collect(Collectors.toList()));
-            }
-            item.setItemMeta(meta);
-        }
-        return item;
-    }
 }

--- a/src/main/java/com/minekarta/kec/gui/MainGui.java
+++ b/src/main/java/com/minekarta/kec/gui/MainGui.java
@@ -8,10 +8,6 @@ import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.inventory.meta.ItemMeta;
-
-import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * The main GUI for the KartaEmeraldCurrency plugin.
@@ -94,24 +90,4 @@ public class MainGui extends AbstractGui {
         }
     }
 
-    // Override createItem to handle placeholders
-    private ItemStack createItem(ConfigurationSection itemConfig, TagResolver resolvers) {
-        ItemStack item = super.createItem(itemConfig);
-        if (item == null) return null;
-
-        ItemMeta meta = item.getItemMeta();
-        if (meta != null) {
-            if (meta.hasDisplayName()) {
-                meta.displayName(MiniMessage.miniMessage().deserialize(MiniMessage.miniMessage().serialize(meta.displayName()), resolvers));
-            }
-            if (meta.hasLore()) {
-                List<String> loreLines = itemConfig.getStringList("lore");
-                meta.lore(loreLines.stream()
-                        .map(line -> MiniMessage.miniMessage().deserialize(line, resolvers))
-                        .collect(Collectors.toList()));
-            }
-            item.setItemMeta(meta);
-        }
-        return item;
-    }
 }


### PR DESCRIPTION
This commit addresses two issues with the GUI item lore:
1.  Internal placeholders were not being consistently applied across all GUIs.
2.  Lore text was incorrectly rendered as italic.

To solve this, the item creation logic has been refactored and centralized into the `AbstractGui` class. This ensures that all GUI items are created with a consistent process that handles placeholder replacement via MiniMessage's `TagResolver`.

The italicization issue is fixed by prepending `<italic:false>` to each lore line before it is parsed, which is the standard way to disable default italics in MiniMessage components.

The duplicated `createItem` methods in `MainGui` and `BankGui` have been removed, and they now inherit the corrected logic from the abstract parent class.