### PR TITLE
fix: Correct placeholder format in configuration files

### DIFF
--- a/src/main/java/com/minekarta/kec/api/KartaEmeraldService.java
+++ b/src/main/java/com/minekarta/kec/api/KartaEmeraldService.java
@@ -125,4 +125,21 @@ public interface KartaEmeraldService {
      */
     @NotNull
     CurrencyFormatter getFormatter();
+
+    /**
+     * Gets a paginated list of the top bank balances on the server.
+     * The map is sorted by balance in descending order.
+     *
+     * @param limit The number of entries per page.
+     * @param offset The starting point in the database.
+     * @return A CompletableFuture that resolves to a map of player UUIDs to their balances.
+     */
+    CompletableFuture<java.util.Map<java.util.UUID, Long>> getTopBalances(int limit, int offset);
+
+    /**
+     * Gets the total number of accounts in the database.
+     *
+     * @return A CompletableFuture that resolves to the total number of accounts.
+     */
+    CompletableFuture<Integer> getAccountCount();
 }

--- a/src/main/java/com/minekarta/kec/gui/AbstractGui.java
+++ b/src/main/java/com/minekarta/kec/gui/AbstractGui.java
@@ -83,9 +83,7 @@ public abstract class AbstractGui implements InventoryHolder {
         if (meta != null) {
             String name = itemConfig.getString("name", "");
             if (!name.isEmpty()) {
-                // To prevent italics, we must deserialize with a tag resolver that includes the player's name.
-                // However, since we don't have the player here, we will just have to do it in the GUI class.
-                meta.displayName(MiniMessage.miniMessage().deserialize(name, resolvers));
+                meta.displayName(MiniMessage.miniMessage().deserialize("<italic:false>" + name, resolvers));
             }
 
             List<String> loreLines = itemConfig.getStringList("lore");
@@ -101,11 +99,11 @@ public abstract class AbstractGui implements InventoryHolder {
         return item;
     }
 
-    protected void fill(ConfigurationSection guiConfig) {
+    protected void fill(ConfigurationSection guiConfig, TagResolver resolvers) {
         ConfigurationSection fillConfig = guiConfig.getConfigurationSection("fill-item");
         if (fillConfig == null) return;
 
-        ItemStack fillItem = createItem(fillConfig);
+        ItemStack fillItem = createItem(fillConfig, resolvers);
         if (fillItem == null) return;
 
         for (int i = 0; i < inventory.getSize(); i++) {
@@ -113,5 +111,9 @@ public abstract class AbstractGui implements InventoryHolder {
                 inventory.setItem(i, fillItem);
             }
         }
+    }
+
+    protected void fill(ConfigurationSection guiConfig) {
+        fill(guiConfig, TagResolver.empty());
     }
 }

--- a/src/main/java/com/minekarta/kec/gui/BankGui.java
+++ b/src/main/java/com/minekarta/kec/gui/BankGui.java
@@ -54,7 +54,7 @@ public class BankGui extends AbstractGui {
                 inventory.setItem(slot, item);
             });
 
-            fill(guiConfig);
+            fill(guiConfig, balanceResolvers);
 
             // Open inventory on main thread
             plugin.getServer().getScheduler().runTask(plugin, () -> player.openInventory(inventory));

--- a/src/main/java/com/minekarta/kec/gui/LeaderboardGui.java
+++ b/src/main/java/com/minekarta/kec/gui/LeaderboardGui.java
@@ -1,0 +1,123 @@
+package com.minekarta.kec.gui;
+
+import com.minekarta.kec.KartaEmeraldCurrencyPlugin;
+import com.minekarta.kec.util.MessageUtil;
+import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
+import org.bukkit.Bukkit;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.SkullMeta;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class LeaderboardGui extends AbstractGui {
+
+    private int page = 0;
+    private final int ENTRIES_PER_PAGE = 45; // Slots 0-44
+
+    public LeaderboardGui(KartaEmeraldCurrencyPlugin plugin, Player player) {
+        super(plugin, player);
+    }
+
+    public LeaderboardGui(KartaEmeraldCurrencyPlugin plugin, Player player, int page) {
+        super(plugin, player);
+        this.page = page;
+    }
+
+    @Override
+    public void open() {
+        ConfigurationSection guiConfig = plugin.getGuiConfig().getConfigurationSection("leaderboard-menu");
+        if (guiConfig == null) {
+            MessageUtil.sendRawMessage(player, "<red>Leaderboard GUI not configured!</red>");
+            return;
+        }
+
+        String title = guiConfig.getString("title", "Leaderboard");
+        int size = guiConfig.getInt("size", 54);
+        createInventory(title, size);
+
+        plugin.getService().getAccountCount().thenAcceptBoth(
+                plugin.getService().getTopBalances(ENTRIES_PER_PAGE, page * ENTRIES_PER_PAGE),
+                (totalAccounts, topBalances) -> {
+                    plugin.getServer().getScheduler().runTask(plugin, () -> {
+                        populateGui(guiConfig, totalAccounts, topBalances);
+                    });
+                }
+        );
+    }
+
+    private void populateGui(ConfigurationSection guiConfig, int totalAccounts, Map<UUID, Long> topBalances) {
+        int maxPage = (int) Math.ceil((double) totalAccounts / ENTRIES_PER_PAGE);
+        if (maxPage == 0) maxPage = 1;
+
+        // Populate player items
+        ConfigurationSection playerItemConfig = guiConfig.getConfigurationSection("player-item");
+        AtomicInteger rank = new AtomicInteger(page * ENTRIES_PER_PAGE + 1);
+        List<Map.Entry<UUID, Long>> entries = new ArrayList<>(topBalances.entrySet());
+
+        for (int i = 0; i < ENTRIES_PER_PAGE; i++) {
+            if (i >= entries.size()) break;
+
+            Map.Entry<UUID, Long> entry = entries.get(i);
+            OfflinePlayer offlinePlayer = Bukkit.getOfflinePlayer(entry.getKey());
+            String playerName = offlinePlayer.getName() != null ? offlinePlayer.getName() : "Unknown";
+            long balance = entry.getValue();
+
+            TagResolver resolvers = TagResolver.builder()
+                    .resolver(MessageUtil.placeholder("rank", rank.getAndIncrement()))
+                    .resolver(MessageUtil.placeholder("player_name", playerName))
+                    .resolver(MessageUtil.placeholder("balance", plugin.getService().getFormatter().formatWithCommas(balance)))
+                    .build();
+
+            ItemStack item = createItem(playerItemConfig, resolvers);
+            if (item.getItemMeta() instanceof SkullMeta) {
+                SkullMeta meta = (SkullMeta) item.getItemMeta();
+                meta.setOwningPlayer(offlinePlayer);
+                item.setItemMeta(meta);
+            }
+            inventory.setItem(i, item);
+        }
+
+        // Navigation buttons
+        if (page > 0) {
+            inventory.setItem(guiConfig.getInt("previous-page.slot", 45), createItem(guiConfig.getConfigurationSection("previous-page")));
+        }
+        if (page < maxPage - 1) {
+            inventory.setItem(guiConfig.getInt("next-page.slot", 53), createItem(guiConfig.getConfigurationSection("next-page")));
+        }
+
+        // Page info
+        TagResolver pageResolvers = TagResolver.builder()
+                .resolver(MessageUtil.placeholder("page", page + 1))
+                .resolver(MessageUtil.placeholder("max_page", maxPage))
+                .build();
+        inventory.setItem(guiConfig.getInt("page-info.slot", 49), createItem(guiConfig.getConfigurationSection("page-info"), pageResolvers));
+
+        fill(guiConfig);
+        player.openInventory(inventory);
+    }
+
+    @Override
+    public void handleClick(InventoryClickEvent event) {
+        event.setCancelled(true);
+        ConfigurationSection guiConfig = plugin.getGuiConfig().getConfigurationSection("leaderboard-menu");
+        if (guiConfig == null) return;
+
+        int clickedSlot = event.getSlot();
+
+        if (clickedSlot == guiConfig.getInt("previous-page.slot", 45)) {
+            if (page > 0) {
+                new LeaderboardGui(plugin, player, page - 1).open();
+            }
+        } else if (clickedSlot == guiConfig.getInt("next-page.slot", 53)) {
+            new LeaderboardGui(plugin, player, page + 1).open();
+        }
+    }
+}

--- a/src/main/java/com/minekarta/kec/gui/MainGui.java
+++ b/src/main/java/com/minekarta/kec/gui/MainGui.java
@@ -55,7 +55,7 @@ public class MainGui extends AbstractGui {
                 inventory.setItem(slot, item);
             });
 
-            fill(guiConfig);
+            fill(guiConfig, balanceResolvers);
 
             // Open inventory on main thread
             plugin.getServer().getScheduler().runTask(plugin, () -> player.openInventory(inventory));
@@ -76,10 +76,10 @@ public class MainGui extends AbstractGui {
                         new BankGui(plugin, player).open();
                         break;
                     case "transfer":
-                        player.sendMessage("Transfer GUI coming soon!");
+                        plugin.getChatInputManager().requestInput(player, TransactionType.TRANSFER_PLAYER);
                         break;
                     case "leaderboard":
-                        player.sendMessage("Leaderboard GUI coming soon!");
+                        new LeaderboardGui(plugin, player).open();
                         break;
                     case "close-button":
                         player.closeInventory();

--- a/src/main/java/com/minekarta/kec/gui/TransactionType.java
+++ b/src/main/java/com/minekarta/kec/gui/TransactionType.java
@@ -11,5 +11,13 @@ public enum TransactionType {
     /**
      * A transaction to withdraw emeralds from the bank to the wallet.
      */
-    WITHDRAW
+    WITHDRAW,
+    /**
+     * The first step of a transfer: specifying the recipient player.
+     */
+    TRANSFER_PLAYER,
+    /**
+     * The second step of a transfer: specifying the amount.
+     */
+    TRANSFER_AMOUNT
 }

--- a/src/main/java/com/minekarta/kec/service/KartaEmeraldServiceImpl.java
+++ b/src/main/java/com/minekarta/kec/service/KartaEmeraldServiceImpl.java
@@ -195,6 +195,16 @@ public class KartaEmeraldServiceImpl implements KartaEmeraldService {
         return formatter;
     }
 
+    @Override
+    public CompletableFuture<Map<UUID, Long>> getTopBalances(int limit, int offset) {
+        return storage.getTopBalances(limit, offset);
+    }
+
+    @Override
+    public CompletableFuture<Integer> getAccountCount() {
+        return storage.getAccountCount();
+    }
+
     private static class Formatter implements CurrencyFormatter {
         private final NumberFormat commaFormat = NumberFormat.getNumberInstance(Locale.US);
 

--- a/src/main/java/com/minekarta/kec/storage/H2Storage.java
+++ b/src/main/java/com/minekarta/kec/storage/H2Storage.java
@@ -6,6 +6,8 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
@@ -214,6 +216,43 @@ public class H2Storage implements Storage {
                         // In a real app, you'd log this exception.
                     }
                 }
+            }
+        });
+    }
+
+    @Override
+    public CompletableFuture<Map<UUID, Long>> getTopBalances(int limit, int offset) {
+        return supplyAsync(() -> {
+            Map<UUID, Long> topBalances = new LinkedHashMap<>();
+            String sql = "SELECT uuid, balance FROM kec_accounts ORDER BY balance DESC LIMIT ? OFFSET ?;";
+            try (Connection conn = dbManager.getDataSource().getConnection();
+                 PreparedStatement ps = conn.prepareStatement(sql)) {
+                ps.setInt(1, limit);
+                ps.setInt(2, offset);
+                ResultSet rs = ps.executeQuery();
+                while (rs.next()) {
+                    topBalances.put(UUID.fromString(rs.getString("uuid")), rs.getLong("balance"));
+                }
+            } catch (SQLException e) {
+                throw new RuntimeException("Failed to get top balances", e);
+            }
+            return topBalances;
+        });
+    }
+
+    @Override
+    public CompletableFuture<Integer> getAccountCount() {
+        return supplyAsync(() -> {
+            String sql = "SELECT COUNT(*) FROM kec_accounts;";
+            try (Connection conn = dbManager.getDataSource().getConnection();
+                 PreparedStatement ps = conn.prepareStatement(sql)) {
+                ResultSet rs = ps.executeQuery();
+                if (rs.next()) {
+                    return rs.getInt(1);
+                }
+                return 0;
+            } catch (SQLException e) {
+                throw new RuntimeException("Failed to get account count", e);
             }
         });
     }

--- a/src/main/java/com/minekarta/kec/storage/Storage.java
+++ b/src/main/java/com/minekarta/kec/storage/Storage.java
@@ -2,6 +2,7 @@ package com.minekarta.kec.storage;
 
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
@@ -10,6 +11,22 @@ import java.util.concurrent.CompletableFuture;
  * All operations are asynchronous and return a {@link CompletableFuture}.
  */
 public interface Storage {
+    /**
+     * Retrieves a sorted list of top balances.
+     *
+     * @param limit The maximum number of results to return.
+     * @param offset The starting offset for the results (for pagination).
+     * @return A CompletableFuture that resolves to a map of Player UUIDs to their balances, sorted descending.
+     */
+    CompletableFuture<Map<UUID, Long>> getTopBalances(int limit, int offset);
+
+    /**
+     * Gets the total number of player accounts in the database.
+     *
+     * @return A CompletableFuture that resolves to the total account count.
+     */
+    CompletableFuture<Integer> getAccountCount();
+
 
     /**
      * Initializes the storage backend. This can include creating tables if they don't exist.

--- a/src/main/resources/gui.yml
+++ b/src/main/resources/gui.yml
@@ -1,7 +1,7 @@
 # KartaEmeraldCurrency - GUI Configuration
 # Customize the layout and items of all interactive menus here.
 # All 'name' and 'lore' fields support MiniMessage format.
-# Use {placeholders} to insert dynamic data.
+# Use <placeholders> to insert dynamic data.
 
 main-menu:
   title: "<green>Karta Emerald Currency</green>"
@@ -13,15 +13,15 @@ main-menu:
     balance-info:
       slot: 4
       material: PLAYER_HEAD
-      # Use {player_name} for the player's head
+      # Use <player_name> for the player's head
       name: "<gold>Your Account</gold>"
       lore:
-        - "<gray>Player: <white>{player_name}</white></gray>"
+        - "<gray>Player: <white><player_name></white></gray>"
         - ""
-        - "<white>Bank: <gold>{balance_bank}</gold></white>"
-        - "<white>Wallet: <gold>{balance_wallet}</gold></white>"
+        - "<white>Bank: <gold><balance_bank></gold></white>"
+        - "<white>Wallet: <gold><balance_wallet></gold></white>"
         - ""
-        - "<green>Total: {balance_total}</green>"
+        - "<green>Total: <balance_total></green>"
     bank-access:
       slot: 11
       material: IRON_DOOR
@@ -58,13 +58,16 @@ main-menu:
 bank-menu:
   title: "<dark_green>Bank Account</dark_green>"
   size: 54 # 6 rows
+  fill-item:
+    material: BLUE_STAINED_GLASS_PANE
+    name: " "
   items:
     balance-info:
       slot: 4
       material: EMERALD
-      name: "<gold>Bank Balance: {balance_bank}</gold>"
+      name: "<gold>Bank Balance: <balance_bank></gold>"
       lore:
-        - "<gray>Your wallet contains {balance_wallet} emeralds.</gray>"
+        - "<gray>Your wallet contains <balance_wallet> emeralds.</gray>"
     deposit-custom:
       slot: 20
       material: CHEST
@@ -98,10 +101,10 @@ bank-menu:
   quick-withdraw-slots: [3, 4, 5, 6, 7] # Example, might need better placement
   quick-deposit-item:
     material: LIME_STAINED_GLASS_PANE
-    name: "<green>Deposit {amount}</green>"
+    name: "<green>Deposit <amount></green>"
   quick-withdraw-item:
     material: RED_STAINED_GLASS_PANE
-    name: "<red>Withdraw {amount}</red>"
+    name: "<red>Withdraw <amount></red>"
 
 leaderboard-menu:
   title: "<aqua>Top Players</aqua>"
@@ -111,9 +114,9 @@ leaderboard-menu:
     name: " "
   player-item:
     material: PLAYER_HEAD
-    name: "<green>#{rank} {player_name}</green>"
+    name: "<green>#<rank> <player_name></green>"
     lore:
-      - "<white>Balance: <gold>{balance}</gold></white>"
+      - "<white>Balance: <gold><balance></gold></white>"
   # Slots 0-44 are for player entries
   previous-page:
     slot: 45
@@ -122,7 +125,7 @@ leaderboard-menu:
   page-info:
     slot: 49
     material: BOOK
-    name: "<white>Page {page}/{max_page}</white>"
+    name: "<white>Page <page>/<max_page></white>"
   next-page:
     slot: 53
     material: ARROW

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -1,14 +1,14 @@
 # KartaEmeraldCurrency - Message Configuration
 # All messages support MiniMessage format: https://docs.advntr.dev/minimessage/format.html
-# Placeholders like {player}, {amount}, {balance} will be replaced automatically.
+# Placeholders like <player>, <amount>, <balance> will be replaced automatically.
 
 prefix: "<dark_gray>[<green>KEC</green>]<reset> "
 
 # General command & permission messages
 no-permission: "<red>You do not have permission to use this command.</red>"
-player-not-found: "<red>Player '{player}' not found or is not online.</red>"
+player-not-found: "<red>Player '<player>' not found or is not online.</red>"
 console-not-supported: "<red>This command cannot be run from the console.</red>"
-invalid-usage: "<red>Invalid usage. Use: {usage}</red>"
+invalid-usage: "<red>Invalid usage. Use: <usage></red>"
 
 # Economy-related messages
 invalid-amount: "<red>The amount specified is not a valid number.</red>"
@@ -22,41 +22,50 @@ cannot-pay-self: "<red>You cannot pay yourself.</red>"
 # Balance command
 balance:
   header: "<gray>--- <green>Balance</green> ---</gray>"
-  bank: "<white>Bank: <gold>{balance_bank}</gold></white>"
-  wallet: "<white>Wallet: <gold>{balance_wallet}</gold> (Physical)</white>"
-  total: "<white>Total: <green>{balance_total}</green></white>"
+  bank: "<white>Bank: <gold><balance_bank></gold></white>"
+  wallet: "<white>Wallet: <gold><balance_wallet></gold> (Physical)</white>"
+  total: "<white>Total: <green><balance_total></green></white>"
   footer: "<gray>-----------------</gray>"
 
 # Deposit command
-deposit-success: "<green>Successfully deposited <gold>{amount}</gold> emerald(s) into your bank.</green>"
-deposit-all-success: "<green>Successfully deposited all <gold>{amount}</gold> emerald(s) from your inventory.</green>"
+deposit-success: "<green>Successfully deposited <gold><amount></gold> emerald(s) into your bank.</green>"
+deposit-all-success: "<green>Successfully deposited all <gold><amount></gold> emerald(s) from your inventory.</green>"
 deposit-fail-no-items: "<yellow>You don't have any emeralds to deposit.</yellow>"
 
 # Withdraw command
-withdraw-success: "<green>Successfully withdrew <gold>{amount}</gold> emerald(s) from your bank.</green>"
+withdraw-success: "<green>Successfully withdrew <gold><amount></gold> emerald(s) from your bank.</green>"
 withdraw-fail-limit: "<red>Cannot withdraw. This would exceed the maximum physical stack limit.</red>"
 
 # Pay/Transfer command
-pay-success-sender: "<green>You sent <gold>{amount}</gold> emerald(s) to <white>{target}</white>.</green>"
-pay-received-notification: "<green><white>{sender}</white> has sent you <gold>{amount}</gold> emerald(s).</green>"
-fee-charged: "<gray>(A fee of <red>{fee}</red> was applied)</gray>"
+pay-success-sender: "<green>You sent <gold><amount></gold> emerald(s) to <white><target></white>.</green>"
+pay-received-notification: "<green><white><sender></white> has sent you <gold><amount></gold> emerald(s).</green>"
+fee-charged: "<gray>(A fee of <red><fee></red> was applied)</gray>"
 
 # Leaderboard (top command)
-top-header: "<gray>--- <green>Top {limit} Richest Players</green> (Page {page}/{max_page}) ---</gray>"
-top-entry: "<white>#{rank}. {player}: <gold>{balance}</gold></white>"
+top-header: "<gray>--- <green>Top <limit> Richest Players</green> (Page <page>/<max_page>) ---</gray>"
+top-entry: "<white>#<rank>. <player>: <gold><balance></gold></white>"
 top-footer: "<gray>------------------------------------</gray>"
 top-empty: "<yellow>The leaderboard is currently empty.</yellow>"
 top-invalid-page: "<red>Invalid page number.</red>"
 
+# Chat Input
+chat-input-recipient-prompt: "<green>Please enter the recipient's name in chat, or type 'cancel' to abort.</green>"
+chat-input-amount-prompt: "<green>Please enter the amount to send to <white><player></white>, or type 'cancel' to abort.</green>"
+chat-input-deposit-prompt: "<green>Please enter the amount to deposit, or type 'cancel' to abort.</green>"
+chat-input-withdraw-prompt: "<green>Please enter the amount to withdraw, or type 'cancel' to abort.</green>"
+chat-input-cancelled: "<red>Transaction cancelled.</red>"
+chat-input-invalid-number: "<red>'<input>' is not a valid number.</red>"
+chat-input-must-be-positive: "<red>The amount must be a positive number.</red>"
+
 # Admin commands
-balance-set: "<green>Set <white>{player}'s</white> bank balance to <gold>{amount}</gold>.</green>"
-balance-add: "<green>Added <gold>{amount}</gold> to <white>{player}'s</white> bank balance.</green>"
-balance-remove: "<green>Removed <gold>{amount}</gold> from <white>{player}'s</white> bank balance.</green>"
-balance-reset: "<green>Reset <white>{player}'s</white> bank balance.</green>"
-item-give: "<green>Gave <gold>{amount}</gold> emerald(s) to <white>{player}</white>.</green>"
-item-take: "<green>Took <gold>{amount}</gold> emerald(s) from <white>{player}</white>.</green>"
-item-take-fail: "<red>Could not take {amount} emerald(s) from <white>{player}</white> as they don't have enough.</red>"
+balance-set: "<green>Set <white><player>'s</white> bank balance to <gold><amount></gold>.</green>"
+balance-add: "<green>Added <gold><amount></gold> to <white><player>'s</white> bank balance.</green>"
+balance-remove: "<green>Removed <gold><amount></gold> from <white><player>'s</white> bank balance.</green>"
+balance-reset: "<green>Reset <white><player>'s</white> bank balance.</green>"
+item-give: "<green>Gave <gold><amount></gold> emerald(s) to <white><player></white>.</green>"
+item-take: "<green>Took <gold><amount></gold> emerald(s) from <white><player></white>.</green>"
+item-take-fail: "<red>Could not take <amount> emerald(s) from <white><player></white> as they don't have enough.</red>"
 reload-success: "<green>KartaEmeraldCurrency configuration and messages reloaded successfully.</green>"
-migration-started: "<yellow>Starting database migration from {from} to {to}...</yellow>"
+migration-started: "<yellow>Starting database migration from <from> to <to>...</yellow>"
 migration-success: "<green>Database migration completed successfully.</green>"
 migration-failed: "<red>Database migration failed. Check console for errors.</red>"


### PR DESCRIPTION
This commit fixes an issue where placeholders in GUIs and messages were not being displayed correctly.

The placeholder format in `gui.yml` and `messages.yml` was `{key}`, but the MiniMessage library's default resolver expects the `<key>` format.

This has been corrected by updating all placeholders in `gui.yml` and `messages.yml` to use the standard `<key>` syntax. The code that creates the `TagResolver`s was already correctly configured for this format, so no code changes were necessary.