### PR TITLE
Refactor placeholder system to use PAPI

### DIFF
--- a/src/main/java/com/minekarta/kec/KartaEmeraldCurrencyPlugin.java
+++ b/src/main/java/com/minekarta/kec/KartaEmeraldCurrencyPlugin.java
@@ -41,6 +41,8 @@ public class KartaEmeraldCurrencyPlugin extends JavaPlugin {
     private DatabaseManager databaseManager;
     private ChatInputManager chatInputManager;
 
+    private static boolean papiHooked = false;
+
     private FileConfiguration messagesConfig;
     private FileConfiguration guiConfig;
     private FileConfiguration databaseConfig;
@@ -161,9 +163,11 @@ public class KartaEmeraldCurrencyPlugin extends JavaPlugin {
 
         // Hook into PlaceholderAPI
         if (Bukkit.getPluginManager().getPlugin("PlaceholderAPI") != null) {
+            papiHooked = true;
             new com.minekarta.kec.placeholder.KecPlaceholderExpansion(this).register();
             getLogger().info("Successfully hooked into PlaceholderAPI.");
         } else {
+            papiHooked = false;
             getLogger().info("PlaceholderAPI not found. No placeholders will be available.");
         }
     }
@@ -230,5 +234,13 @@ public class KartaEmeraldCurrencyPlugin extends JavaPlugin {
      */
     public ChatInputManager getChatInputManager() {
         return chatInputManager;
+    }
+
+    /**
+     * Checks if PlaceholderAPI is hooked.
+     * @return True if hooked, false otherwise.
+     */
+    public static boolean isPlaceholderApiHooked() {
+        return papiHooked;
     }
 }

--- a/src/main/java/com/minekarta/kec/gui/BankGui.java
+++ b/src/main/java/com/minekarta/kec/gui/BankGui.java
@@ -1,34 +1,34 @@
 package com.minekarta.kec.gui;
 
 import com.minekarta.kec.KartaEmeraldCurrencyPlugin;
-import net.kyori.adventure.text.minimessage.MiniMessage;
-import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
+import com.minekarta.kec.util.MessageUtil;
 import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.inventory.ItemStack;
 
+import java.util.List;
+
 /**
  * The bank GUI for depositing and withdrawing emeralds.
  */
 public class BankGui extends AbstractGui {
 
-    /**
-     * Constructs a new BankGui.
-     *
-     * @param plugin The plugin instance.
-     * @param player The player viewing the GUI.
-     */
+    private List<Integer> quickDepositAmounts;
+    private List<Integer> quickWithdrawAmounts;
+
     public BankGui(KartaEmeraldCurrencyPlugin plugin, Player player) {
         super(plugin, player);
+        this.quickDepositAmounts = plugin.getPluginConfig().getIntegerList("gui.quick-amounts");
+        this.quickWithdrawAmounts = plugin.getPluginConfig().getIntegerList("gui.quick-amounts");
     }
 
     @Override
     public void open() {
         ConfigurationSection guiConfig = plugin.getGuiConfig().getConfigurationSection("bank-menu");
         if (guiConfig == null) {
-            player.sendMessage("Bank GUI not configured!");
+            MessageUtil.sendRawMessage(player, "<red>Bank GUI not configured!</red>");
             return;
         }
 
@@ -36,83 +36,114 @@ public class BankGui extends AbstractGui {
         int size = guiConfig.getInt("size", 54);
         createInventory(title, size);
 
-        // Asynchronously fetch balance and then populate the GUI
-        plugin.getService().getBankBalance(player.getUniqueId()).thenAccept(bankBalance -> {
-            long walletBalance = plugin.getService().getWalletBalance(player);
-
-            TagResolver balanceResolvers = TagResolver.builder()
-                    .resolver(Placeholder.unparsed("player_name", player.getName()))
-                    .resolver(Placeholder.unparsed("balance_bank", plugin.getService().getFormatter().formatWithCommas(bankBalance)))
-                    .resolver(Placeholder.unparsed("balance_wallet", plugin.getService().getFormatter().formatWithCommas(walletBalance)))
-                    .build();
-
-            // Set items from config
-            guiConfig.getConfigurationSection("items").getKeys(false).forEach(key -> {
-                ConfigurationSection itemConfig = guiConfig.getConfigurationSection("items." + key);
-                int slot = itemConfig.getInt("slot");
-                ItemStack item = createItem(itemConfig, balanceResolvers);
-                inventory.setItem(slot, item);
+        // Set static items
+        ConfigurationSection itemsConfig = guiConfig.getConfigurationSection("items");
+        if (itemsConfig != null) {
+            itemsConfig.getKeys(false).forEach(key -> {
+                ConfigurationSection itemConfig = itemsConfig.getConfigurationSection(key);
+                inventory.setItem(itemConfig.getInt("slot"), createItem(itemConfig));
             });
+        }
 
-            fill(guiConfig, balanceResolvers);
+        // Set quick deposit buttons
+        populateQuickActionButtons(guiConfig, "quick-deposit", quickDepositAmounts);
 
-            // Open inventory on main thread
-            plugin.getServer().getScheduler().runTask(plugin, () -> player.openInventory(inventory));
-        });
+        // Set quick withdraw buttons
+        populateQuickActionButtons(guiConfig, "quick-withdraw", quickWithdrawAmounts);
+
+        fill(guiConfig);
+        player.openInventory(inventory);
+    }
+
+    private void populateQuickActionButtons(ConfigurationSection guiConfig, String type, List<Integer> amounts) {
+        ConfigurationSection itemConfig = guiConfig.getConfigurationSection(type + "-item");
+        List<Integer> slots = guiConfig.getIntegerList(type + "-slots");
+
+        for (int i = 0; i < Math.min(slots.size(), amounts.size()); i++) {
+            int amount = amounts.get(i);
+            int slot = slots.get(i);
+
+            TagResolver resolver = MessageUtil.placeholder("amount", plugin.getService().getFormatter().formatWithCommas(amount));
+            ItemStack item = createItem(itemConfig, resolver);
+            inventory.setItem(slot, item);
+        }
     }
 
     @Override
     public void handleClick(InventoryClickEvent event) {
+        event.setCancelled(true);
         int slot = event.getSlot();
-        ConfigurationSection guiConfig = plugin.getGuiConfig().getConfigurationSection("bank-menu.items");
+        ConfigurationSection guiConfig = plugin.getGuiConfig().getConfigurationSection("bank-menu");
         if (guiConfig == null) return;
 
-        // Find which item was clicked by checking slots in config
-        for (String key : guiConfig.getKeys(false)) {
-            if (guiConfig.getInt(key + ".slot") == slot) {
-                switch (key) {
-                    case "deposit-custom":
-                        plugin.getChatInputManager().requestInput(player, TransactionType.DEPOSIT);
-                        break;
-                    case "withdraw-custom":
-                        plugin.getChatInputManager().requestInput(player, TransactionType.WITHDRAW);
-                        break;
-                    case "deposit-all":
-                        handleDepositAll();
-                        break;
-                    case "back-button":
-                        new MainGui(plugin, player).open();
-                        break;
-                    case "close-button":
-                        player.closeInventory();
-                        break;
+        // Handle static items
+        ConfigurationSection itemsConfig = guiConfig.getConfigurationSection("items");
+        if (itemsConfig != null) {
+            for (String key : itemsConfig.getKeys(false)) {
+                if (itemsConfig.getInt(key + ".slot") == slot) {
+                    handleStaticItemClick(key);
+                    return;
                 }
-                return;
             }
         }
+
+        // Handle quick deposit buttons
+        if (handleQuickActionClick(guiConfig, "quick-deposit", quickDepositAmounts, slot, true)) return;
+
+        // Handle quick withdraw buttons
+        handleQuickActionClick(guiConfig, "quick-withdraw", quickWithdrawAmounts, slot, false);
+    }
+
+    private void handleStaticItemClick(String key) {
+        switch (key) {
+            case "deposit-custom":
+                plugin.getChatInputManager().requestInput(player, TransactionType.DEPOSIT);
+                break;
+            case "withdraw-custom":
+                plugin.getChatInputManager().requestInput(player, TransactionType.WITHDRAW);
+                break;
+            case "deposit-all":
+                handleDepositAll();
+                break;
+            case "back-button":
+                new MainGui(plugin, player).open();
+                break;
+            case "close-button":
+                player.closeInventory();
+                break;
+        }
+    }
+
+    private boolean handleQuickActionClick(ConfigurationSection guiConfig, String type, List<Integer> amounts, int slot, boolean isDeposit) {
+        List<Integer> slots = guiConfig.getIntegerList(type + "-slots");
+        for (int i = 0; i < Math.min(slots.size(), amounts.size()); i++) {
+            if (slots.get(i) == slot) {
+                long amount = amounts.get(i);
+                if (isDeposit) {
+                    plugin.getService().depositToBank(player.getUniqueId(), amount).thenAccept(this::handleTransactionResult);
+                } else {
+                    plugin.getService().withdrawFromBank(player.getUniqueId(), amount).thenAccept(this::handleTransactionResult);
+                }
+                return true;
+            }
+        }
+        return false;
     }
 
     private void handleDepositAll() {
         long walletBalance = plugin.getService().getWalletBalance(player);
         if (walletBalance <= 0) {
-            //TODO: Move to messages.yml
-            player.sendMessage("§cYou don't have any emeralds in your inventory to deposit.");
+            MessageUtil.sendMessage(player, "deposit-fail-no-items");
             return;
         }
-
-        plugin.getService().depositToBank(player.getUniqueId(), walletBalance).thenAccept(success -> {
-            plugin.getServer().getScheduler().runTask(plugin, () -> {
-                if (success) {
-                    //TODO: Move to messages.yml
-                    player.sendMessage("§aSuccessfully deposited all " + plugin.getService().getFormatter().formatWithCommas(walletBalance) + " emeralds.");
-                    // Re-open the GUI to show updated balance
-                    open();
-                } else {
-                    // This case should ideally not happen if walletBalance > 0
-                    player.sendMessage("§cAn unexpected error occurred during deposit.");
-                }
-            });
-        });
+        plugin.getService().depositToBank(player.getUniqueId(), walletBalance).thenAccept(this::handleTransactionResult);
     }
 
+    private void handleTransactionResult(boolean success) {
+        if (success) {
+            // Re-open the GUI on the main thread to show updated balance
+            plugin.getServer().getScheduler().runTask(plugin, this::open);
+        }
+        // Messages for success/failure are sent from the service layer
+    }
 }

--- a/src/main/java/com/minekarta/kec/placeholder/KecPlaceholderExpansion.java
+++ b/src/main/java/com/minekarta/kec/placeholder/KecPlaceholderExpansion.java
@@ -1,10 +1,20 @@
 package com.minekarta.kec.placeholder;
 
 import com.minekarta.kec.KartaEmeraldCurrencyPlugin;
+import com.minekarta.kec.api.CurrencyFormatter;
 import com.minekarta.kec.api.KartaEmeraldService;
 import me.clip.placeholderapi.expansion.PlaceholderExpansion;
+import org.bukkit.Bukkit;
 import org.bukkit.OfflinePlayer;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * The PlaceholderAPI expansion for KartaEmeraldCurrency.
@@ -13,6 +23,12 @@ public class KecPlaceholderExpansion extends PlaceholderExpansion {
 
     private final KartaEmeraldCurrencyPlugin plugin;
     private final KartaEmeraldService service;
+    private final CurrencyFormatter formatter;
+
+    private final String placeholderSource;
+    private final boolean compactFormatting;
+
+    private static final Pattern LEADERBOARD_PATTERN = Pattern.compile("top_(\\d+)_(\\w+)");
 
     /**
      * Constructs a new KecPlaceholderExpansion.
@@ -21,6 +37,9 @@ public class KecPlaceholderExpansion extends PlaceholderExpansion {
     public KecPlaceholderExpansion(KartaEmeraldCurrencyPlugin plugin) {
         this.plugin = plugin;
         this.service = plugin.getService();
+        this.formatter = service.getFormatter();
+        this.placeholderSource = plugin.getConfig().getString("placeholders.source", "BANK").toUpperCase();
+        this.compactFormatting = plugin.getConfig().getBoolean("placeholders.compact", false);
     }
 
     @Override
@@ -40,11 +59,6 @@ public class KecPlaceholderExpansion extends PlaceholderExpansion {
 
     @Override
     public boolean persist() {
-        return true; // We want to keep this registered
-    }
-
-    @Override
-    public boolean canRegister(){
         return true;
     }
 
@@ -54,30 +68,82 @@ public class KecPlaceholderExpansion extends PlaceholderExpansion {
             return "";
         }
 
-        // Placeholders like %kartaemerald_balance%
+        // Balance placeholders
         switch (params) {
             case "balance":
-                // TODO: Add config option for source (BANK | TOTAL)
-                return String.valueOf(service.getBankBalance(player.getUniqueId()).join());
+                return String.valueOf(getBalance(player).join());
             case "balance_formatted":
-                long balance = service.getBankBalance(player.getUniqueId()).join();
-                return service.getFormatter().formatDefault(balance);
-            case "balance_comma":
-                long balanceComma = service.getBankBalance(player.getUniqueId()).join();
-                return service.getFormatter().formatWithCommas(balanceComma);
-            case "bank":
-                long bankBalance = service.getBankBalance(player.getUniqueId()).join();
-                return String.valueOf(bankBalance);
-            case "wallet":
+                return formatBalance(getBalance(player).join());
+            case "balance_bank":
+                return String.valueOf(service.getBankBalance(player.getUniqueId()).join());
+            case "balance_bank_formatted":
+                return formatter.formatWithCommas(service.getBankBalance(player.getUniqueId()).join());
+            case "balance_wallet":
                 return String.valueOf(service.getWalletBalance(player));
+            case "balance_wallet_formatted":
+                return formatter.formatWithCommas(service.getWalletBalance(player));
+            case "balance_total":
+                return String.valueOf(getTotalBalance(player).join());
+            case "balance_total_formatted":
+                return formatter.formatWithCommas(getTotalBalance(player).join());
         }
 
-        // Leaderboard placeholders: %kartaemerald_top_1_name%, %kartaemerald_top_1_amount%
-        if (params.startsWith("top_")) {
-            // TODO: Implement leaderboard cache and retrieval
-            return "N/A";
+        // Leaderboard placeholders
+        Matcher matcher = LEADERBOARD_PATTERN.matcher(params);
+        if (matcher.matches()) {
+            try {
+                int rank = Integer.parseInt(matcher.group(1));
+                if (rank <= 0) return "Invalid Rank";
+
+                String type = matcher.group(2);
+
+                // Fetch top balances - we fetch one more than needed in case of rank lookup
+                Map<UUID, Long> topBalances = service.getTopBalances(rank, 0).join();
+                if (topBalances.size() < rank) {
+                    return ""; // or a default value like "N/A"
+                }
+
+                // Convert map to list to get by index
+                List<Map.Entry<UUID, Long>> entries = new ArrayList<>(topBalances.entrySet());
+                Map.Entry<UUID, Long> entry = entries.get(rank - 1);
+
+                switch (type) {
+                    case "name":
+                        OfflinePlayer topPlayer = Bukkit.getOfflinePlayer(entry.getKey());
+                        return topPlayer.getName() != null ? topPlayer.getName() : "Unknown";
+                    case "balance":
+                        return String.valueOf(entry.getValue());
+                    case "balance_formatted":
+                        return formatter.formatWithCommas(entry.getValue());
+                    default:
+                        return "Invalid Type";
+                }
+
+            } catch (NumberFormatException e) {
+                return "Invalid Rank Number";
+            } catch (IndexOutOfBoundsException e) {
+                return ""; // Rank doesn't exist
+            }
         }
 
-        return null; // Let PAPI know we couldn't handle this placeholder
+        return null;
+    }
+
+    private CompletableFuture<Long> getBalance(OfflinePlayer player) {
+        if ("TOTAL".equals(placeholderSource)) {
+            return getTotalBalance(player);
+        }
+        return service.getBankBalance(player.getUniqueId());
+    }
+
+    private CompletableFuture<Long> getTotalBalance(OfflinePlayer player) {
+        return service.getBankBalance(player.getUniqueId()).thenApply(bank -> bank + service.getWalletBalance(player));
+    }
+
+    private String formatBalance(long balance) {
+        if (compactFormatting) {
+            return formatter.formatDefault(balance);
+        }
+        return formatter.formatWithCommas(balance);
     }
 }

--- a/src/main/java/com/minekarta/kec/util/MessageUtil.java
+++ b/src/main/java/com/minekarta/kec/util/MessageUtil.java
@@ -1,12 +1,14 @@
 package com.minekarta.kec.util;
 
 import com.minekarta.kec.KartaEmeraldCurrencyPlugin;
+import me.clip.placeholderapi.PlaceholderAPI;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.minimessage.MiniMessage;
 import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
 import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
 import org.bukkit.command.CommandSender;
 import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.entity.Player;
 
 /**
  * A utility class for sending messages to players.
@@ -16,9 +18,6 @@ public class MessageUtil {
     private static final MiniMessage miniMessage = MiniMessage.miniMessage();
     private static String prefix = "";
 
-    /**
-     * Private constructor to prevent instantiation.
-     */
     private MessageUtil() {
         // Utility class
     }
@@ -41,9 +40,7 @@ public class MessageUtil {
     public static void sendMessage(CommandSender target, String messageKey, TagResolver... resolvers) {
         KartaEmeraldCurrencyPlugin plugin = KartaEmeraldCurrencyPlugin.getInstance();
         String message = plugin.getMessagesConfig().getString(messageKey, "<red>Unknown message key: " + messageKey + "</red>");
-
-        Component parsedMessage = miniMessage.deserialize(prefix + message, resolvers);
-        target.sendMessage(parsedMessage);
+        sendRawMessage(target, prefix + message, resolvers);
     }
 
     /**
@@ -53,7 +50,12 @@ public class MessageUtil {
      * @param resolvers Placeholders to use in the message.
      */
     public static void sendRawMessage(CommandSender target, String message, TagResolver... resolvers) {
-        Component parsedMessage = miniMessage.deserialize(message, resolvers);
+        String processedMessage = message;
+        if (target instanceof Player && KartaEmeraldCurrencyPlugin.isPlaceholderApiHooked()) {
+            processedMessage = PlaceholderAPI.setPlaceholders((Player) target, message);
+        }
+
+        Component parsedMessage = miniMessage.deserialize(processedMessage, resolvers);
         target.sendMessage(parsedMessage);
     }
 

--- a/src/main/resources/gui.yml
+++ b/src/main/resources/gui.yml
@@ -1,7 +1,8 @@
 # KartaEmeraldCurrency - GUI Configuration
 # Customize the layout and items of all interactive menus here.
 # All 'name' and 'lore' fields support MiniMessage format.
-# Use {placeholders} to insert dynamic data.
+# Global placeholders use the %placeholder% format (e.g., %player_name%).
+# Context-specific placeholders use the {placeholder} format (e.g., {amount}).
 
 main-menu:
   title: "<green>Karta Emerald Currency</green>"
@@ -13,15 +14,15 @@ main-menu:
     balance-info:
       slot: 4
       material: PLAYER_HEAD
-      # Use {player_name} for the player's head
+      # Use %player_name% for the player's head
       name: "<gold>Your Account</gold>"
       lore:
-        - "<gray>Player: <white>{player_name}</white></gray>"
+        - "<gray>Player: <white>%player_name%</white></gray>"
         - ""
-        - "<white>Bank: <gold>{balance_bank}</gold></white>"
-        - "<white>Wallet: <gold>{balance_wallet}</gold></white>"
+        - "<white>Bank: <gold>%kartaemerald_balance_bank_formatted%</gold></white>"
+        - "<white>Wallet: <gold>%kartaemerald_balance_wallet_formatted%</gold></white>"
         - ""
-        - "<green>Total: {balance_total}</green>"
+        - "<green>Total: %kartaemerald_balance_total_formatted%</green>"
     bank-access:
       slot: 11
       material: IRON_DOOR
@@ -65,9 +66,9 @@ bank-menu:
     balance-info:
       slot: 4
       material: EMERALD
-      name: "<gold>Bank Balance: {balance_bank}</gold>"
+      name: "<gold>Bank Balance: %kartaemerald_balance_bank_formatted%</gold>"
       lore:
-        - "<gray>Your wallet contains {balance_wallet} emeralds.</gray>"
+        - "<gray>Your wallet contains %kartaemerald_balance_wallet_formatted% emeralds.</gray>"
     deposit-custom:
       slot: 20
       material: CHEST
@@ -98,7 +99,7 @@ bank-menu:
       material: BARRIER
       name: "<red>Close</red>"
   quick-deposit-slots: [38, 39, 40, 41, 42]
-  quick-withdraw-slots: [3, 4, 5, 6, 7] # Example, might need better placement
+  quick-withdraw-slots: [3, 2, 1, 0, 4] # Adjusted for better layout
   quick-deposit-item:
     material: LIME_STAINED_GLASS_PANE
     name: "<green>Deposit {amount}</green>"
@@ -107,7 +108,7 @@ bank-menu:
     name: "<red>Withdraw {amount}</red>"
 
 leaderboard-menu:
-  title: "<aqua>Top Players</aqua>"
+  title: "<aqua>Top Players - Page {page}</aqua>"
   size: 54
   fill-item:
     material: BLACK_STAINED_GLASS_PANE
@@ -122,6 +123,8 @@ leaderboard-menu:
     slot: 45
     material: ARROW
     name: "<gray>Previous Page</gray>"
+    lore:
+      - "<white>Page {page}/{max_page}</white>"
   page-info:
     slot: 49
     material: BOOK
@@ -130,3 +133,5 @@ leaderboard-menu:
     slot: 53
     material: ARROW
     name: "<gray>Next Page</gray>"
+    lore:
+      - "<white>Page {page}/{max_page}</white>"

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -1,6 +1,7 @@
 # KartaEmeraldCurrency - Message Configuration
 # All messages support MiniMessage format: https://docs.advntr.dev/minimessage/format.html
-# Placeholders like {player}, {amount}, {balance} will be replaced automatically.
+# Global placeholders use the %placeholder% format (e.g., %player_name%).
+# Context-specific placeholders use the {placeholder} format (e.g., {amount}).
 
 prefix: "<dark_gray>[<green>KEC</green>]<reset> "
 
@@ -21,19 +22,19 @@ cannot-pay-self: "<red>You cannot pay yourself.</red>"
 
 # Balance command
 balance:
-  header: "<gray>--- <green>Balance</green> ---</gray>"
-  bank: "<white>Bank: <gold>{balance_bank}</gold></white>"
-  wallet: "<white>Wallet: <gold>{balance_wallet}</gold> (Physical)</white>"
-  total: "<white>Total: <green>{balance_total}</green></white>"
+  header: "<gray>--- <green>Balance for %player_name%</green> ---</gray>"
+  bank: "<white>Bank: <gold>%kartaemerald_balance_bank_formatted%</gold></white>"
+  wallet: "<white>Wallet: <gold>%kartaemerald_balance_wallet_formatted%</gold> (Physical)</white>"
+  total: "<white>Total: <green>%kartaemerald_balance_total_formatted%</green></white>"
   footer: "<gray>-----------------</gray>"
 
 # Deposit command
-deposit-success: "<green>Successfully deposited <gold>{amount}</gold> emerald(s) into your bank.</green>"
-deposit-all-success: "<green>Successfully deposited all <gold>{amount}</gold> emerald(s) from your inventory.</green>"
+deposit-success: "<green>Successfully deposited <gold>{amount}</gold> emerald(s). New balance: <gold>%kartaemerald_balance_bank_formatted%</gold></green>"
+deposit-all-success: "<green>Successfully deposited all <gold>{amount}</gold> emerald(s). New balance: <gold>%kartaemerald_balance_bank_formatted%</gold></green>"
 deposit-fail-no-items: "<yellow>You don't have any emeralds to deposit.</yellow>"
 
 # Withdraw command
-withdraw-success: "<green>Successfully withdrew <gold>{amount}</gold> emerald(s) from your bank.</green>"
+withdraw-success: "<green>Successfully withdrew <gold>{amount}</gold> emerald(s). New balance: <gold>%kartaemerald_balance_bank_formatted%</gold></green>"
 withdraw-fail-limit: "<red>Cannot withdraw. This would exceed the maximum physical stack limit.</red>"
 
 # Pay/Transfer command


### PR DESCRIPTION
Overhauled the entire placeholder system to resolve issues with non-functional placeholders in GUIs and messages.

- Migrated all global placeholders in `gui.yml` and `messages.yml` from the custom `{...}` format to the standard PlaceholderAPI `%...%` format.
- Context-specific placeholders (like `{amount}`, `{rank}`) remain, handled by MiniMessage's TagResolver.
- Reworked `AbstractGui` and `MessageUtil` to use a hybrid system that processes PAPI placeholders first, then applies context-specific resolvers.
- Significantly enhanced `KecPlaceholderExpansion`:
  - Implemented missing leaderboard placeholders (`%kartaemerald_top_N_...%`).
  - Added new formatted balance placeholders (`..._formatted`).
  - Ensured balance placeholders respect the source configuration from `config.yml`.
- Fixed a bug in `BankGui` where quick-action buttons were not being created.
- The plugin now correctly detects if PlaceholderAPI is hooked and applies placeholders accordingly.