### PR TITLE
Fix: Fire CurrencyBalanceChangeEvent asynchronously

### DIFF
--- a/src/main/java/com/minekarta/kec/service/KartaEmeraldServiceImpl.java
+++ b/src/main/java/com/minekarta/kec/service/KartaEmeraldServiceImpl.java
@@ -108,7 +108,7 @@ public class KartaEmeraldServiceImpl implements KartaEmeraldService {
         return syncPart.thenCompose(finalAmount -> {
             return economyDataHandler.addBalance(playerId, finalAmount).thenApply(newBalance -> {
                 long oldBalance = newBalance - finalAmount;
-                Bukkit.getScheduler().runTask(plugin, () -> {
+                Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
                     CurrencyBalanceChangeEvent changeEvent = new CurrencyBalanceChangeEvent(true, playerId, CurrencyBalanceChangeEvent.ChangeReason.DEPOSIT, oldBalance, newBalance);
                     Bukkit.getPluginManager().callEvent(changeEvent);
                 });
@@ -163,7 +163,8 @@ public class KartaEmeraldServiceImpl implements KartaEmeraldService {
                     Bukkit.getScheduler().runTask(plugin, () -> {
                         Material currencyMaterial = Material.valueOf(plugin.getPluginConfig().getString("currency.material", "EMERALD"));
                         player.getInventory().addItem(new ItemStack(currencyMaterial, (int) (long)finalAmount));
-
+                    });
+                    Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
                         long oldBalance = balance;
                         CurrencyBalanceChangeEvent changeEvent = new CurrencyBalanceChangeEvent(true, playerId, CurrencyBalanceChangeEvent.ChangeReason.WITHDRAW, oldBalance, newBalance);
                         Bukkit.getPluginManager().callEvent(changeEvent);


### PR DESCRIPTION
The Paper API requires that `CurrencyBalanceChangeEvent` be fired from an asynchronous task. The previous code was firing it from the main server thread inside a `runTask` call, which caused an `IllegalStateException`.

This commit fixes the issue by using `runTaskAsynchronously` to fire the event in both the `depositToBank` and `withdrawFromBank` methods.

In the `withdrawFromBank` method, the inventory update, which must be run on the main thread, is kept in a `runTask` call, while the event is fired in a separate `runTaskAsynchronously` call.