### PR TITLE
fix(storage): Configure SnakeYAML to trust PlayerData class

### DIFF
--- a/src/main/java/com/minekarta/kec/storage/provider/FileStorageProvider.java
+++ b/src/main/java/com/minekarta/kec/storage/provider/FileStorageProvider.java
@@ -5,6 +5,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.scheduler.BukkitTask;
 import org.jetbrains.annotations.NotNull;
 import org.yaml.snakeyaml.DumperOptions;
+import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.Constructor;
 import org.yaml.snakeyaml.representer.Representer;
@@ -41,7 +42,11 @@ public class FileStorageProvider implements StorageProvider {
         options.setPrettyFlow(true);
         Representer representer = new Representer(new DumperOptions());
         representer.getPropertyUtils().setSkipMissingProperties(true);
-        this.yaml = new Yaml(new Constructor(PlayerData.class, new org.yaml.snakeyaml.LoaderOptions()), representer, options);
+
+        LoaderOptions loaderOptions = new LoaderOptions();
+        loaderOptions.setTagInspector(tag -> tag.getClassName().equals(PlayerData.class.getName()));
+
+        this.yaml = new Yaml(new Constructor(PlayerData.class, loaderOptions), representer, options);
     }
 
     @Override


### PR DESCRIPTION
Resolves a `org.yaml.snakeyaml.composer.ComposerException` that occurred during player data loading. This error was caused by recent versions of SnakeYAML disallowing the deserialization of arbitrary Java objects by default for security reasons.

This commit configures the `Yaml` instance in `FileStorageProvider` with custom `LoaderOptions`. A `TagInspector` is now used to explicitly and safely trust the `!!com.minekarta.kec.storage.provider.PlayerData` tag, allowing player data to be deserialized correctly without compromising security by enabling all tags.